### PR TITLE
fp: round-trippable serde with golden format tests

### DIFF
--- a/ext/crates/fp/Cargo.toml
+++ b/ext/crates/fp/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aligned-vec = "0.6.4"
+aligned-vec = { version = "0.6.4", features = ["serde"] }
 build_const = "0.2.2"
 byteorder = "1.5.0"
 cfg-if = "1.0.1"

--- a/ext/crates/fp/src/field/fp.rs
+++ b/ext/crates/fp/src/field/fp.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use super::{
     Field,
     element::{FieldElement, FieldElementContainer},
@@ -8,7 +10,7 @@ pub use crate::prime::fp::*;
 use crate::{constants::BITS_PER_LIMB, limb::Limb, prime::Prime};
 
 /// A prime field. This is just a wrapper around a prime.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Fp<P> {
     p: P,
 }

--- a/ext/crates/fp/src/matrix/matrix_inner.rs
+++ b/ext/crates/fp/src/matrix/matrix_inner.rs
@@ -4,6 +4,7 @@ use aligned_vec::AVec;
 use either::Either;
 use itertools::Itertools;
 use maybe_rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use super::{QuasiInverse, Subspace};
 use crate::{
@@ -19,7 +20,7 @@ use crate::{
 /// The way we store matrices means it is easier to perform row operations than column operations,
 /// and the way we use matrices means we want our matrices to act on the right. Hence we think of
 /// vectors as row vectors.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Matrix {
     fp: Fp<ValidPrime>,
     rows: usize,

--- a/ext/crates/fp/src/matrix/quasi_inverse.rs
+++ b/ext/crates/fp/src/matrix/quasi_inverse.rs
@@ -2,6 +2,7 @@ use std::io;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 use super::Matrix;
 use crate::{
@@ -17,7 +18,7 @@ use crate::{
 ///    everything (with the standard basis).
 ///  * `preimage` - The actual quasi-inverse, where the basis of the image is that given by
 ///    `image`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QuasiInverse {
     image: Option<Vec<isize>>,
     preimage: Matrix,

--- a/ext/crates/fp/src/matrix/subspace.rs
+++ b/ext/crates/fp/src/matrix/subspace.rs
@@ -2,6 +2,7 @@ use std::{io, ops::Deref};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 use super::Matrix;
 use crate::{
@@ -18,7 +19,7 @@ use crate::{
 /// # Fields
 ///  * `matrix` - A matrix in reduced row echelon, whose number of columns is the dimension of the
 ///    ambient space and each row is a basis vector of the subspace.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct Subspace {
     matrix: Matrix,

--- a/ext/crates/fp/src/vector/fp_wrapper/mod.rs
+++ b/ext/crates/fp/src/vector/fp_wrapper/mod.rs
@@ -239,22 +239,39 @@ impl<'a> IntoIterator for &'a FpVector {
 impl_from!();
 impl_try_into!();
 
+// `FpVector`'s serde format routes through `FqVector<Fp<ValidPrime>>`, giving a uniform
+// representation across all primes: the prime is encoded in the data, so round-tripping works
+// without out-of-band context. This is what the zarr save system relies on.
+//
+// Callers whose wire format must stay a flat `Vec<u32>` (e.g. the sseq_gui web frontend, which
+// reads vectors as plain JS arrays) should declare their fields as `Vec<u32>` and convert at the
+// boundary rather than relying on `FpVector`'s own serde impl.
 impl Serialize for FpVector {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        Vec::<u32>::from(self).serialize(serializer)
+        use crate::field::Fp;
+        let p = self.prime();
+        let fq = Fp::new(p);
+        let v = FqVector::from_raw_parts(fq, self.len(), self.limbs().to_vec());
+        v.serialize(serializer)
     }
 }
 
 impl<'de> Deserialize<'de> for FpVector {
-    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        panic!("Deserializing FpVector not supported");
-        // This is needed for ext-websocket/actions to be happy
+        use crate::field::{Field, Fp};
+        let v: FqVector<Fp<ValidPrime>> = FqVector::deserialize(deserializer)?;
+        let p = v.fq().characteristic();
+        // Reconstruct an `FpVector` by round-tripping through the binary limb format. The
+        // intermediate byte buffer is small and only allocated on deserialize.
+        let mut bytes = Vec::new();
+        v.to_bytes(&mut bytes).map_err(serde::de::Error::custom)?;
+        Self::from_bytes(p, v.len(), &mut &bytes[..]).map_err(serde::de::Error::custom)
     }
 }
 

--- a/ext/crates/fp/src/vector/inner.rs
+++ b/ext/crates/fp/src/vector/inner.rs
@@ -1,13 +1,15 @@
 // This generates better llvm optimization
 #![allow(clippy::int_plus_one)]
 
+use serde::{Deserialize, Serialize};
+
 use crate::{field::Field, limb::Limb};
 
 /// A vector over a finite field.
 ///
 /// Interally, it packs entries of the vectors into limbs. However, this is an abstraction that must
 /// not leave the `fp` library.
-#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct FqVector<F: Field> {
     fq: F,
     len: usize,

--- a/ext/crates/fp/tests/serde_format.rs
+++ b/ext/crates/fp/tests/serde_format.rs
@@ -1,0 +1,177 @@
+//! Tests for the serde impls on `FpVector`, `Matrix`, `Subspace`, and `QuasiInverse`.
+//!
+//! Two kinds of tests:
+//!
+//! 1. **Round-trip** (`*_roundtrip`). Serialize a value to JSON, deserialize it back, and assert
+//!    equality. Driven by `proptest` using the existing `Arbitrary` impls on `FqVector`, `Matrix`,
+//!    and `Subspace`. These verify that the serde impls are mutually consistent across a broad
+//!    spread of primes, dimensions, and limb counts.
+//!
+//! 2. **Golden format** (`*_json_format`). Serialize a known small value to JSON and compare
+//!    against an expected string pinned via `expect-test`. These verify that the on-the-wire format
+//!    doesn't drift silently — any future change to the serde representation must be explicitly
+//!    acknowledged by running `UPDATE_EXPECT=1 cargo test -p fp --test serde_format`. Includes F_2
+//!    vectors spanning multiple limbs to catch mistakes in the multi-limb encoding used by
+//!    `FqVector::limbs` / `Matrix::data`.
+
+use expect_test::expect;
+use fp::{
+    field::Fp,
+    matrix::{
+        Matrix, QuasiInverse, Subspace,
+        arbitrary::{MatrixArbParams, SubspaceArbParams},
+    },
+    prime::ValidPrime,
+    vector::{FpVector, FqVector, arbitrary::FqVectorArbParams},
+};
+use proptest::prelude::*;
+
+fn p(n: u32) -> ValidPrime {
+    ValidPrime::new(n)
+}
+
+// ---------- Proptest strategies ----------
+
+/// Arbitrary `FpVector` with length up to 300 (covers 0–5 limbs at F_2).
+fn arb_fpvector() -> impl Strategy<Value = FpVector> {
+    any_with::<FqVector<Fp<ValidPrime>>>(FqVectorArbParams {
+        fq: None,
+        len: (0..=300usize).boxed(),
+    })
+    .prop_map(|v| v.into())
+}
+
+/// Arbitrary small `Matrix` (dimensions capped so the generated JSON stays manageable).
+fn arb_matrix() -> impl Strategy<Value = Matrix> {
+    any_with::<Matrix>(MatrixArbParams {
+        p: None,
+        rows: (0..=20usize).boxed(),
+        columns: (0..=20usize).boxed(),
+    })
+}
+
+/// Arbitrary small `Subspace`.
+fn arb_subspace() -> impl Strategy<Value = Subspace> {
+    any_with::<Subspace>(SubspaceArbParams {
+        p: None,
+        dim: (0..=20usize).boxed(),
+    })
+}
+
+/// Arbitrary `QuasiInverse` whose `image` field is either `None` or an arbitrary `Vec<isize>`.
+///
+/// We don't enforce semantic consistency between `image` and `preimage` because this test only
+/// exercises serde, and the serialization treats both fields as opaque data.
+fn arb_quasi_inverse() -> impl Strategy<Value = QuasiInverse> {
+    let image = proptest::option::of(proptest::collection::vec(-1isize..100, 0..20usize));
+    (arb_matrix(), image).prop_map(|(m, image)| QuasiInverse::new(image, m))
+}
+
+// ---------- Round-trip tests ----------
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    #[test]
+    fn fpvector_roundtrip(v in arb_fpvector()) {
+        let s = serde_json::to_string(&v).unwrap();
+        let v2: FpVector = serde_json::from_str(&s).unwrap();
+        prop_assert_eq!(v, v2);
+    }
+
+    #[test]
+    fn matrix_roundtrip(m in arb_matrix()) {
+        let s = serde_json::to_string(&m).unwrap();
+        let m2: Matrix = serde_json::from_str(&s).unwrap();
+        prop_assert_eq!(m, m2);
+    }
+
+    #[test]
+    fn subspace_roundtrip(s in arb_subspace()) {
+        let json = serde_json::to_string(&s).unwrap();
+        let s2: Subspace = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(s, s2);
+    }
+
+    #[test]
+    fn quasi_inverse_roundtrip(qi in arb_quasi_inverse()) {
+        let s = serde_json::to_string(&qi).unwrap();
+        let qi2: QuasiInverse = serde_json::from_str(&s).unwrap();
+        prop_assert_eq!(qi, qi2);
+    }
+}
+
+// ---------- Golden format tests ----------
+//
+// To update after an intentional format change:
+//
+//     UPDATE_EXPECT=1 cargo test -p fp --test serde_format
+
+#[test]
+fn fpvector_p2_single_limb_json_format() {
+    let v = FpVector::from_slice(p(2), &[1, 0, 1, 1, 0]);
+    let s = serde_json::to_string(&v).unwrap();
+    expect![[r#"{"fq":{"p":2},"len":5,"limbs":[13]}"#]].assert_eq(&s);
+}
+
+/// F_2 vector spanning exactly two limbs (entries 0..64 in limb 0, entries 64..128 in limb 1).
+#[test]
+fn fpvector_p2_two_limbs_json_format() {
+    let mut entries = vec![0u32; 128];
+    entries[0] = 1;
+    entries[1] = 1;
+    entries[63] = 1;
+    entries[64] = 1;
+    entries[127] = 1;
+    let v = FpVector::from_slice(p(2), &entries);
+    let s = serde_json::to_string(&v).unwrap();
+    expect![[r#"{"fq":{"p":2},"len":128,"limbs":[9223372036854775811,9223372036854775809]}"#]]
+        .assert_eq(&s);
+}
+
+/// F_2 vector straddling three limbs (130 entries, with a bit set in every limb).
+#[test]
+fn fpvector_p2_three_limbs_json_format() {
+    let mut entries = vec![0u32; 130];
+    entries[5] = 1;
+    entries[70] = 1;
+    entries[129] = 1;
+    let v = FpVector::from_slice(p(2), &entries);
+    let s = serde_json::to_string(&v).unwrap();
+    expect![[r#"{"fq":{"p":2},"len":130,"limbs":[32,64,2]}"#]].assert_eq(&s);
+}
+
+#[test]
+fn fpvector_p3_json_format() {
+    let v = FpVector::from_slice(p(3), &[1, 2, 0, 2, 1]);
+    let s = serde_json::to_string(&v).unwrap();
+    expect![[r#"{"fq":{"p":3},"len":5,"limbs":[5137]}"#]].assert_eq(&s);
+}
+
+#[test]
+fn fpvector_p5_json_format() {
+    let v = FpVector::from_slice(p(5), &[4, 2, 0, 3]);
+    let s = serde_json::to_string(&v).unwrap();
+    expect![[r#"{"fq":{"p":5},"len":4,"limbs":[98372]}"#]].assert_eq(&s);
+}
+
+#[test]
+fn matrix_p2_json_format() {
+    let m = Matrix::from_vec(p(2), &[vec![1, 0, 1], vec![0, 1, 1]]);
+    let s = serde_json::to_string(&m).unwrap();
+    expect![[
+        r#"{"fp":{"p":2},"rows":2,"physical_rows":2,"columns":3,"data":[5,6],"stride":1,"pivots":[]}"#
+    ]]
+    .assert_eq(&s);
+}
+
+#[test]
+fn quasi_inverse_p2_json_format() {
+    let preimage = Matrix::from_vec(p(2), &[vec![1, 0, 1], vec![0, 1, 1]]);
+    let qi = QuasiInverse::new(Some(vec![0, 1, -1]), preimage);
+    let s = serde_json::to_string(&qi).unwrap();
+    expect![[
+        r#"{"image":[0,1,-1],"preimage":{"fp":{"p":2},"rows":2,"physical_rows":2,"columns":3,"data":[5,6],"stride":1,"pivots":[]}}"#
+    ]]
+    .assert_eq(&s);
+}

--- a/web_ext/sseq_gui/src/actions.rs
+++ b/web_ext/sseq_gui/src/actions.rs
@@ -323,7 +323,7 @@ impl ActionT for SetDifferential {}
 
 /// The `FpVector` fields are serialized as bare `Vec<u32>` (entries in the basis of the ambient F_p
 /// vector space) rather than going through `FpVector`'s `Serialize` impl.
-/// 
+///
 /// The sseq_gui web frontend reads these as flat JS arrays (see `interface/panels.js`:
 /// `d[0].reduce(...)`, `d[0].indexOf(1)`, `permanentClasses.map(rowToKaTeX)`), and that frontend is
 /// the only consumer, so we do the `FpVector → Vec<u32>` conversion at the `SetClass` boundary and

--- a/web_ext/sseq_gui/src/actions.rs
+++ b/web_ext/sseq_gui/src/actions.rs
@@ -321,13 +321,20 @@ pub struct SetDifferential {
 }
 impl ActionT for SetDifferential {}
 
+/// The `FpVector` fields are serialized as bare `Vec<u32>` (entries in the basis of the ambient F_p
+/// vector space) rather than going through `FpVector`'s `Serialize` impl.
+/// 
+/// The sseq_gui web frontend reads these as flat JS arrays (see `interface/panels.js`:
+/// `d[0].reduce(...)`, `d[0].indexOf(1)`, `permanentClasses.map(rowToKaTeX)`), and that frontend is
+/// the only consumer, so we do the `FpVector → Vec<u32>` conversion at the `SetClass` boundary and
+/// keep `FpVector`'s own serde format free to carry prime metadata for the zarr save system.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetClass {
     pub b: Bidegree,
     pub state: ClassState,
-    pub permanents: Vec<FpVector>,
-    pub classes: Vec<Vec<FpVector>>,
-    pub decompositions: Vec<(FpVector, String, Bidegree)>,
+    pub permanents: Vec<Vec<u32>>,
+    pub classes: Vec<Vec<Vec<u32>>>,
+    pub decompositions: Vec<(Vec<u32>, String, Bidegree)>,
     pub class_names: Vec<String>,
 }
 impl ActionT for SetClass {}

--- a/web_ext/sseq_gui/src/sseq.rs
+++ b/web_ext/sseq_gui/src/sseq.rs
@@ -244,7 +244,10 @@ impl<P: SseqProfile<2>> SseqWrapper<P> {
             ClassState::InProgress
         };
 
-        let mut decompositions: Vec<(FpVector, String, Bidegree)> = Vec::new();
+        // `SetClass` carries vectors as `Vec<u32>` so the JS frontend can read them as plain arrays
+        // (see the comment on `SetClass`). Convert here rather than relying on `FpVector`'s
+        // `Serialize` impl.
+        let mut decompositions: Vec<(Vec<u32>, String, Bidegree)> = Vec::new();
         for (name, prod) in &self.products {
             let prod_b = prod.inner.b;
             let prod_origin_b = b - prod_b;
@@ -255,7 +258,7 @@ impl<P: SseqProfile<2>> SseqWrapper<P> {
                         continue;
                     }
                     decompositions.push((
-                        matrix.row(i).to_owned(),
+                        matrix.row(i).iter().collect(),
                         format!("{name} {}", self.class_names[prod_origin_b][i]),
                         prod_b,
                     ));
@@ -273,7 +276,7 @@ impl<P: SseqProfile<2>> SseqWrapper<P> {
                     .inner
                     .permanent_classes(b)
                     .basis()
-                    .map(FpSlice::to_owned)
+                    .map(|row| row.iter().collect())
                     .collect(),
                 class_names: self.class_names[b].clone(),
                 decompositions,
@@ -281,8 +284,8 @@ impl<P: SseqProfile<2>> SseqWrapper<P> {
                     .inner
                     .page_data(b)
                     .iter()
-                    .map(|x| x.gens().map(FpSlice::to_owned).collect())
-                    .collect::<Vec<Vec<FpVector>>>(),
+                    .map(|x| x.gens().map(|row| row.iter().collect()).collect())
+                    .collect(),
             }),
         });
     }

--- a/web_ext/sseq_gui/src/sseq.rs
+++ b/web_ext/sseq_gui/src/sseq.rs
@@ -4,7 +4,7 @@ use bivec::BiVec;
 use fp::{
     matrix::{Matrix, Subquotient},
     prime::ValidPrime,
-    vector::{FpSlice, FpVector},
+    vector::FpSlice,
 };
 use once::MultiIndexed;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary

Prequel PR to the zarr save system rework. Extracted to minimize that PR's diff and land the `fp` serde changes independently, with format tests.

**`fp` crate**
- Derive `Serialize`/`Deserialize` on `Fp<P>`, `FqVector<F>`, `Matrix`, `Subspace`, `QuasiInverse`. Enables the zarr save system (and any other downstream serializer) to store these types directly without hand-rolled byte formats.
- Rework `FpVector`'s manual serde impl to route through `FqVector<Fp<ValidPrime>>` so the prime is encoded in the wire format. The previous impl serialized as a bare `Vec<u32>` and panicked on deserialize, so it couldn't survive a round-trip.
- `aligned-vec` gains the `serde` feature (needed for `Matrix::data: AVec<Limb>`).

**Web frontend boundary fix (`web_ext/sseq_gui/`)**
- The sseq_gui web frontend reads `SetClass.permanents` / `.classes` / `.decompositions` as flat JS arrays of u32 (see `interface/panels.js`: `d[0].reduce(...)`, `d[0].indexOf(1)`, `permanentClasses.map(rowToKaTeX)`). If `FpVector`'s serde format becomes prime-tagged, those JS sites break.
- Fix: `SetClass` now carries those fields as `Vec<Vec<u32>>` (etc.) and converts from `FpVector` at the message boundary in `sseq.rs`. The JS wire format is unchanged, and `FpVector`'s own serde is free to carry prime metadata.

**Tests (`crates/fp/tests/serde_format.rs`, 177 lines)**
- Proptest round-trips for `FpVector` / `Matrix` / `Subspace` / `QuasiInverse`, 128 cases each, F_2 vectors up to 5 limbs.
- Golden tests pinned via `expect-test` for `p ∈ {2, 3, 5}`, including F_2 vectors spanning exactly two and three limbs — catches mistakes in the multi-limb encoding.
- To update after an intentional format change: `UPDATE_EXPECT=1 cargo test -p fp --test serde_format`.

## Test plan

- [x] `cargo test -p fp --test serde_format` — all 11 tests pass (4 proptests × 128 cases + 7 goldens)
- [x] `nix run ./ext#test` — full CI pipeline (lint, tests, benchmarks, miri) green
- [ ] JS frontend smoke test on an actual sseq_gui session (optional — type changes are purely at the Rust/JS boundary, and JS-side representation is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)