### PR TITLE
ExtAlgebra Phase 2: secondary d₂ differential

### DIFF
--- a/ext/examples/product.rs
+++ b/ext/examples/product.rs
@@ -15,26 +15,26 @@ fn main() -> anyhow::Result<()> {
     ext::utils::init_logging()?;
 
     let resolution = Arc::new(query_module(None, true)?);
-    let alg = ExtAlgebra::from_resolution(resolution)?;
+    let e2 = ExtAlgebra::from_resolution(resolution)?;
 
     let shift = Bidegree::n_s(
         query::raw("n of Ext class", str::parse),
         query::raw("s of Ext class", str::parse),
     );
 
-    let dim = alg.dimension(shift);
+    let dim = e2.dimension(shift);
     if dim == 0 {
         panic!("No classes in bidegree {shift}");
     }
     let v: Vec<u32> = query::vector("Input Ext class", dim);
-    let x = alg.element(shift, &v);
+    let x = e2.element(shift, &v);
 
-    for b in alg.unit().iter_nonzero_stem() {
+    for b in e2.unit().iter_nonzero_stem() {
         // `None` means `b + shift` is out of the computed range, so skip it.
-        let Some(rows) = alg.multiply_into(&x, b) else {
+        let Some(rows) = e2.multiply_into(&x, b) else {
             continue;
         };
-        for (g, row) in alg.unit_basis(b).into_iter().zip(rows.iter()) {
+        for (g, row) in e2.unit_basis(b).into_iter().zip(rows.iter()) {
             let coords: Vec<u32> = row.iter().collect();
             if coords.iter().any(|&c| c != 0) {
                 println!("x · x_{g} = {coords:?}");

--- a/ext/examples/product.rs
+++ b/ext/examples/product.rs
@@ -1,0 +1,45 @@
+//! Computes products in Ext by left-multiplication by a fixed class.
+//!
+//! The program asks for a module `M` and a class `x ∈ Ext(M, k)`. It then prints the products of
+//! `x` with every basis class of `Ext(k, k)` that lands in a computed bidegree.
+//!
+//! This is the primary (i.e. non-secondary) analogue of [`secondary_product`](../secondary_product),
+//! written against the [`ExtAlgebra`] abstraction so the plumbing stays out of the way.
+
+use std::sync::Arc;
+
+use ext::{chain_complex::FreeChainComplex, ext_algebra::ExtAlgebra, utils::query_module};
+use sseq::coordinates::Bidegree;
+
+fn main() -> anyhow::Result<()> {
+    ext::utils::init_logging()?;
+
+    let resolution = Arc::new(query_module(None, true)?);
+    let alg = ExtAlgebra::from_resolution(resolution)?;
+
+    let shift = Bidegree::n_s(
+        query::raw("n of Ext class", str::parse),
+        query::raw("s of Ext class", str::parse),
+    );
+
+    let dim = alg.dimension(shift);
+    if dim == 0 {
+        panic!("No classes in bidegree {shift}");
+    }
+    let v: Vec<u32> = query::vector("Input Ext class", dim);
+    let x = alg.element(shift, &v);
+
+    for b in alg.unit().iter_nonzero_stem() {
+        // `None` means `b + shift` is out of the computed range, so skip it.
+        let Some(rows) = alg.multiply_into(&x, b) else {
+            continue;
+        };
+        for (g, row) in alg.unit_basis(b).into_iter().zip(rows.iter()) {
+            let coords: Vec<u32> = row.iter().collect();
+            if coords.iter().any(|&c| c != 0) {
+                println!("x · x_{g} = {coords:?}");
+            }
+        }
+    }
+    Ok(())
+}

--- a/ext/examples/secondary.rs
+++ b/ext/examples/secondary.rs
@@ -50,41 +50,47 @@ use std::sync::Arc;
 use algebra::module::Module;
 use ext::{
     chain_complex::{ChainComplex, FreeChainComplex},
-    secondary::*,
+    ext_algebra::{ExtAlgebra, secondary::SecondaryExtAlgebra},
     utils::query_module,
 };
-use sseq::coordinates::{Bidegree, BidegreeGenerator};
+use sseq::coordinates::Bidegree;
 
 fn main() -> anyhow::Result<()> {
     ext::utils::init_logging()?;
 
     let resolution = Arc::new(query_module(Some(algebra::AlgebraType::Milnor), true)?);
 
-    let lift = SecondaryResolution::new(Arc::clone(&resolution));
+    // The d2 differential is intrinsic to the resolution and needs no unit, so we avoid the unit
+    // setup with `without_unit`.
+    let sec_e2 = SecondaryExtAlgebra::new(Arc::new(ExtAlgebra::without_unit(resolution)));
+
     if let Some(s) = ext::utils::secondary_job() {
-        lift.compute_partial(s);
+        sec_e2.compute_partial(s);
         return Ok(());
     }
 
-    lift.extend_all();
+    sec_e2.extend_all();
 
+    let e2 = sec_e2.ext_algebra();
     let d2_shift = Bidegree::n_s(-1, 2);
 
-    // Iterate through target of the d2
-    for b in lift.underlying().iter_nonzero_stem() {
+    // Iterate through the target of the d2, in the same order as before.
+    for b in e2.resolution().iter_nonzero_stem() {
         if b.s() < 3 {
             continue;
         }
 
-        if b.t() - 1 > resolution.module(b.s() - 2).max_computed_degree() {
+        // The source of the d2 must be computed (its degree may exceed what `module(b.s() - 2)`
+        // reaches when resolving through a stem).
+        if b.t() - 1 > e2.resolution().module(b.s() - 2).max_computed_degree() {
             continue;
         }
-        let homotopy = lift.homotopy(b.s());
-        let m = homotopy.homotopies.hom_k(b.t() - 1);
 
-        for (i, entry) in m.into_iter().enumerate() {
-            let source_gen = BidegreeGenerator::new(b - d2_shift, i);
-            println!("d_2 x_{source_gen} = {entry:?}");
+        for g in e2.basis(b - d2_shift) {
+            if let Some(dx) = sec_e2.d2(&e2.generator(g)) {
+                let entry: Vec<u32> = dx.vec().iter().collect();
+                println!("d_2 x_{g} = {entry:?}");
+            }
         }
     }
 

--- a/ext/examples/secondary_product.rs
+++ b/ext/examples/secondary_product.rs
@@ -25,111 +25,61 @@ use std::sync::Arc;
 use algebra::module::Module;
 use ext::{
     chain_complex::{ChainComplex, FreeChainComplex},
-    resolution_homomorphism::ResolutionHomomorphism,
-    secondary::*,
+    ext_algebra::{ExtAlgebra, secondary::SecondaryExtAlgebra},
+    secondary::{LAMBDA_BIDEGREE, SecondaryLift},
     utils::query_module,
 };
-use fp::{matrix::Matrix, prime::Prime, vector::FpVector};
-use itertools::Itertools;
-use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
+use sseq::coordinates::{Bidegree, BidegreeGenerator};
 
 fn main() -> anyhow::Result<()> {
     ext::utils::init_logging()?;
 
     let resolution = Arc::new(query_module(Some(algebra::AlgebraType::Milnor), true)?);
-
-    let (is_unit, unit) = ext::utils::get_unit(Arc::clone(&resolution))?;
-
-    let p = resolution.prime();
+    let e2 = Arc::new(ExtAlgebra::from_resolution(Arc::clone(&resolution))?);
 
     let name: String = query::raw("Name of product", str::parse);
-
     let shift = Bidegree::n_s(
         query::raw(&format!("n of Ext class {name}"), str::parse),
         query::raw(&format!("s of Ext class {name}"), str::parse),
     );
 
-    let hom = ResolutionHomomorphism::new(name, Arc::clone(&resolution), Arc::clone(&unit), shift);
-
-    let mut matrix = Matrix::new(p, hom.source.number_of_gens_in_bidegree(shift), 1);
-
-    if matrix.rows() == 0 || matrix.columns() == 0 {
+    let dim = e2.dimension(shift);
+    if dim == 0 {
         panic!("No classes in this bidegree");
     }
-    let v: Vec<u32> = query::vector("Input ext class", matrix.rows());
-    for (i, &x) in v.iter().enumerate() {
-        matrix.row_mut(i).set_entry(0, x);
-    }
+    let v: Vec<u32> = query::vector("Input ext class", dim);
+    let x = e2.element(shift, &v);
 
-    if !is_unit {
+    // Ensure the unit is resolved far enough to support the products.
+    if !e2.is_unit() {
         let res_max = Bidegree::n_s(
             resolution.module(0).max_computed_degree(),
             resolution.next_homological_degree() - 1,
         );
-        unit.compute_through_stem(res_max - shift);
+        e2.unit().compute_through_stem(res_max - shift);
     }
 
-    hom.extend_step(shift, Some(&matrix));
-    hom.extend_all();
+    let sec_e2 = Arc::new(SecondaryExtAlgebra::new(Arc::clone(&e2)));
+    sec_e2.extend_all();
 
-    let res_lift = SecondaryResolution::new(Arc::clone(&resolution));
-    res_lift.extend_all();
+    // Check that the class survives to E3 (supports no d2).
+    assert!(sec_e2.survives(&x), "Class supports a non-zero d2");
 
-    // Check that class survives to E3.
-    {
-        let m = res_lift.homotopy(shift.s() + 2).homotopies.hom_k(shift.t());
-        assert_eq!(m.len(), v.len());
-        let mut sum = vec![0; m[0].len()];
-        for (x, d2) in v.iter().zip_eq(&m) {
-            sum.iter_mut().zip_eq(d2).for_each(|(a, b)| *a += x * b);
-        }
-        assert!(
-            sum.iter().all(|x| x.is_multiple_of(p.as_u32())),
-            "Class supports a non-zero d2"
-        );
-    }
-    let res_lift = Arc::new(res_lift);
-
-    let unit_lift = if is_unit {
-        Arc::clone(&res_lift)
-    } else {
-        let lift = SecondaryResolution::new(Arc::clone(&unit));
-        lift.extend_all();
-        Arc::new(lift)
-    };
-
-    let hom = Arc::new(hom);
-    let hom_lift = SecondaryResolutionHomomorphism::new(
-        Arc::clone(&res_lift),
-        Arc::clone(&unit_lift),
-        Arc::clone(&hom),
-    );
+    let lift = sec_e2.secondary_product_lift(&x);
 
     if let Some(s) = ext::utils::secondary_job() {
-        hom_lift.compute_partial(s);
+        lift.underlying().extend_all();
+        lift.compute_partial(s);
         return Ok(());
     }
 
-    hom_lift.extend_all();
+    // `x` multiplies on the left; the printed name is bracketed as in the original output.
+    let disp = format!("[{name}]");
 
-    // Compute E3 page
-    let res_sseq = Arc::new(res_lift.e3_page());
-    let unit_sseq = if is_unit {
-        Arc::clone(&res_sseq)
-    } else {
-        Arc::new(unit_lift.e3_page())
-    };
-
-    fn get_page_data(sseq: &sseq::Sseq<2, sseq::Adams>, b: Bidegree) -> &fp::matrix::Subquotient {
-        let d = sseq.page_data(b);
-        &d[std::cmp::min(3, d.len() - 1)]
-    }
-
-    let name = hom_lift.name();
-    // Iterate through the multiplicand
-    for b in unit.iter_nonzero_stem() {
-        // The potential target has to be hit, and we need to have computed (the data need for) the
-        // d2 that hits the potential target.
+    // Iterate through the multiplicand.
+    for b in e2.unit().iter_nonzero_stem() {
+        // The potential target has to be hit, and we need to have computed (the data needed for)
+        // the d2 that hits the potential target.
         if !resolution.has_computed_bidegree(b + shift + LAMBDA_BIDEGREE) {
             continue;
         }
@@ -137,48 +87,36 @@ fn main() -> anyhow::Result<()> {
             continue;
         }
 
-        let page_data = get_page_data(unit_sseq.as_ref(), b);
-
-        let target_num_gens = resolution.number_of_gens_in_bidegree(b + shift);
-        let lambda_num_gens = resolution.number_of_gens_in_bidegree(b + shift + LAMBDA_BIDEGREE);
-
+        let target_num_gens = e2.dimension(b + shift);
+        let lambda_num_gens = e2.dimension(b + shift + LAMBDA_BIDEGREE);
         if target_num_gens == 0 && lambda_num_gens == 0 {
             continue;
         }
 
-        // First print the products with non-surviving classes
-        if target_num_gens > 0 {
-            let hom_k = hom.get_map((b + shift).s()).hom_k(b.t());
-            for i in page_data.complement_pivots() {
+        let page = sec_e2.unit_page_data(b);
+
+        // First the products with non-surviving classes: these are just λ times the (primary)
+        // product, read off the multiplication map.
+        if target_num_gens > 0
+            && let Some(rows) = e2.multiply_into(&x, b)
+        {
+            for i in page.complement_pivots() {
                 let g = BidegreeGenerator::new(b, i);
-                println!("{name} λ x_{g} = λ {:?}", hom_k[i]);
+                let entry: Vec<u32> = rows.row(i).iter().collect();
+                println!("{disp} λ x_{g} = λ {entry:?}");
             }
         }
 
-        // Now print the secondary products
-        if page_data.subspace_dimension() == 0 {
-            continue;
-        }
-
-        let mut outputs = vec![
-            FpVector::new(p, target_num_gens + lambda_num_gens);
-            page_data.subspace_dimension()
-        ];
-
-        hom_lift.hom_k(
-            Some(&res_sseq),
-            b,
-            page_data.subspace_gens(),
-            outputs.iter_mut().map(FpVector::as_slice_mut),
-        );
-        for (g, output) in page_data.subspace_gens().zip_eq(outputs) {
+        // Now the genuinely secondary products with surviving classes.
+        for prod in sec_e2.secondary_multiply_into(&x, b) {
             println!(
-                "{name} [{basis_string}] = {} + λ {}",
-                output.slice(0, target_num_gens),
-                output.slice(target_num_gens, target_num_gens + lambda_num_gens),
-                basis_string = BidegreeElement::new(b, g.to_owned()).to_basis_string(),
+                "{disp} [{basis}] = {ext} + λ {lambda}",
+                basis = prod.source.to_basis_string(),
+                ext = prod.ext_part.as_slice(),
+                lambda = prod.lambda_part.as_slice(),
             );
         }
     }
+
     Ok(())
 }

--- a/ext/src/ext_algebra.rs
+++ b/ext/src/ext_algebra.rs
@@ -1,0 +1,277 @@
+//! A bigraded-algebra view of a resolution.
+//!
+//! [`ExtAlgebra`] wraps a resolution of a module `M` together with the resolution of the base
+//! field `k` (the "unit"), and presents $\Ext(M, k)$ as a bigraded module over the bigraded
+//! algebra $\Ext(k, k)$. When `M == k` this is the algebra $\Ext(k, k)$ itself.
+//!
+//! The goal is ergonomics: computing a product of Ext classes is a single [`ExtAlgebra::multiply`]
+//! call instead of the manual [`ResolutionHomomorphism`] + `extend` + `hom_k` plumbing that the
+//! examples currently re-derive. This is the foundational layer; the secondary differential ($d_2$)
+//! and Massey products are planned follow-ups.
+//!
+//! # Conventions
+//! A product is realised by a [`ResolutionHomomorphism`] built from a fixed multiplier class living
+//! in $\Ext(M, k)$ (source = resolution of `M`, target = resolution of `k`). That single chain map
+//! computes the products of the multiplier with *all* classes of $\Ext(k, k)$. We cache one such
+//! map per *generator* of $\Ext(M, k)$ (keyed by [`BidegreeGenerator`]); a product by a general
+//! class is assembled at request time as the corresponding linear combination of generator maps.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use fp::{matrix::Matrix, prime::ValidPrime, vector::FpVector};
+use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
+
+use crate::{
+    chain_complex::{AugmentedChainComplex, FreeChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+    utils::{QueryModuleResolution, get_unit},
+};
+
+/// $\Ext(M, k)$ as a bigraded module over the bigraded algebra $\Ext(k, k)$, backed by a
+/// resolution. See the [module-level documentation](self) for conventions.
+pub struct ExtAlgebra<CC: FreeChainComplex> {
+    /// Resolution of `M`; products land in its Ext.
+    resolution: Arc<CC>,
+    /// Resolution of the base field `k`. `Arc`-shared with `resolution` when `M == k`.
+    unit: Arc<CC>,
+    is_unit: bool,
+    /// One multiplication map per generator of $\Ext(M, k)$, built and extended on demand.
+    products: DashMap<BidegreeGenerator, Arc<ResolutionHomomorphism<CC, CC>>>,
+}
+
+impl ExtAlgebra<QueryModuleResolution> {
+    /// Build an [`ExtAlgebra`] from a resolution, deriving the unit via [`get_unit`].
+    ///
+    /// This may prompt for the unit's save directory when `M != k` (see [`get_unit`]); for a fully
+    /// non-interactive setup, use [`ExtAlgebra::new`] with an explicit unit instead.
+    pub fn from_resolution(resolution: Arc<QueryModuleResolution>) -> anyhow::Result<Self> {
+        let (_, unit) = get_unit(Arc::clone(&resolution))?;
+        Ok(Self::new(resolution, unit))
+    }
+
+    /// Ensure both the resolution and the unit are computed through the given stem.
+    pub fn compute_through_stem(&self, max: Bidegree) {
+        self.unit.compute_through_stem(max);
+        if !self.is_unit {
+            self.resolution.compute_through_stem(max);
+        }
+    }
+}
+
+impl<CC: FreeChainComplex> ExtAlgebra<CC> {
+    /// Build an [`ExtAlgebra`] from an explicit `(resolution, unit)` pair.
+    pub fn new(resolution: Arc<CC>, unit: Arc<CC>) -> Self {
+        assert_eq!(resolution.prime(), unit.prime());
+        Self {
+            is_unit: Arc::ptr_eq(&resolution, &unit),
+            resolution,
+            unit,
+            products: DashMap::new(),
+        }
+    }
+
+    pub fn resolution(&self) -> &Arc<CC> {
+        &self.resolution
+    }
+
+    pub fn unit(&self) -> &Arc<CC> {
+        &self.unit
+    }
+
+    pub fn is_unit(&self) -> bool {
+        self.is_unit
+    }
+
+    pub fn prime(&self) -> ValidPrime {
+        self.resolution.prime()
+    }
+
+    /// Ensure both the resolution and the unit are computed through the given bidegree.
+    pub fn compute_through_bidegree(&self, b: Bidegree) {
+        self.unit.compute_through_bidegree(b);
+        if !self.is_unit {
+            self.resolution.compute_through_bidegree(b);
+        }
+    }
+
+    /// The dimension of $\Ext^{s,t}(M, k)$ at the given bidegree.
+    pub fn dimension(&self, b: Bidegree) -> usize {
+        self.resolution.number_of_gens_in_bidegree(b)
+    }
+
+    /// The basis generators of $\Ext(M, k)$ at the given bidegree.
+    pub fn basis(&self, b: Bidegree) -> Vec<BidegreeGenerator> {
+        (0..self.dimension(b))
+            .map(|i| BidegreeGenerator::new(b, i))
+            .collect()
+    }
+
+    /// A class in $\Ext(M, k)$ from its coordinates in the generator basis at bidegree `b`.
+    pub fn element(&self, b: Bidegree, coords: &[u32]) -> BidegreeElement {
+        assert_eq!(self.dimension(b), coords.len());
+        BidegreeElement::new(b, FpVector::from_slice(self.prime(), coords))
+    }
+
+    /// A single generator of $\Ext(M, k)$ as a class.
+    pub fn generator(&self, g: BidegreeGenerator) -> BidegreeElement {
+        let ambient = self.dimension(g.degree());
+        assert!(ambient > g.idx());
+        g.into_element(self.prime(), self.dimension(g.degree()))
+    }
+
+    /// The dimension of $\Ext(k, k)$ at the given bidegree (the multiplicand/"scalar" side).
+    pub fn unit_dimension(&self, b: Bidegree) -> usize {
+        self.unit.number_of_gens_in_bidegree(b)
+    }
+
+    /// The basis generators of $\Ext(k, k)$ at the given bidegree.
+    pub fn unit_basis(&self, b: Bidegree) -> Vec<BidegreeGenerator> {
+        (0..self.unit_dimension(b))
+            .map(|i| BidegreeGenerator::new(b, i))
+            .collect()
+    }
+
+    /// A class in $\Ext(k, k)$ from its coordinates in the generator basis at bidegree `b`.
+    pub fn unit_element(&self, b: Bidegree, coords: &[u32]) -> BidegreeElement {
+        assert_eq!(self.unit_dimension(b), coords.len());
+        BidegreeElement::new(b, FpVector::from_slice(self.prime(), coords))
+    }
+}
+
+impl<CC> ExtAlgebra<CC>
+where
+    CC: FreeChainComplex + AugmentedChainComplex,
+{
+    /// The multiplication map for a single generator `g` of $\Ext(M, k)$, built and cached on
+    /// first use. The returned map is *not* guaranteed to be extended; [`ExtAlgebra::multiply_into`]
+    /// extends it as needed.
+    pub fn generator_product_map(
+        &self,
+        g: BidegreeGenerator,
+    ) -> Arc<ResolutionHomomorphism<CC, CC>> {
+        if let Some(map) = self.products.get(&g) {
+            return Arc::clone(&map);
+        }
+
+        let dim = self.resolution.number_of_gens_in_bidegree(g.degree());
+        let mut class = vec![0u32; dim];
+        class[g.idx()] = 1;
+
+        let name = format!("prod_{}_{}_{}", g.n(), g.s(), g.idx());
+        let hom = Arc::new(ResolutionHomomorphism::from_class(
+            name,
+            Arc::clone(&self.resolution),
+            Arc::clone(&self.unit),
+            g.degree(),
+            &class,
+        ));
+
+        Arc::clone(self.products.entry(g).or_insert(hom).value())
+    }
+
+    /// Left-multiplication by the class `x` (in $\Ext(M, k)$), applied to every basis generator of
+    /// $\Ext(k, k)$ at bidegree `b`.
+    ///
+    /// Returns `None` when the product is out of the computed range — that is, when `b` or
+    /// `b + x.degree()` has not been resolved — so callers never mistake an uncomputed product for a
+    /// zero one. Otherwise returns a matrix with one row per generator of $\Ext(k, k)$ at `b`; row
+    /// `j` is the product `x · g_j` expressed in the generator basis of $\Ext(M, k)$ at bidegree
+    /// `b + x.degree()`. A computed-but-empty bidegree yields a valid zero-dimension matrix, not
+    /// `None`.
+    pub fn multiply_into(&self, x: &BidegreeElement, b: Bidegree) -> Option<Matrix> {
+        let shift = x.degree();
+        let target = b + shift;
+
+        if !self.unit.has_computed_bidegree(b) || !self.resolution.has_computed_bidegree(target) {
+            return None;
+        }
+
+        let unit_dim = self.unit.number_of_gens_in_bidegree(b);
+        let res_dim = self.resolution.number_of_gens_in_bidegree(target);
+        let mut matrix = Matrix::new(self.prime(), unit_dim, res_dim);
+
+        for (i, c) in x.vec().iter_nonzero() {
+            let map = self.generator_product_map(BidegreeGenerator::new(shift, i));
+            map.extend_all();
+
+            // `hom_k(b.t())[j][k]`: `j` indexes the multiplicand generator of the unit at `b`, `k`
+            // indexes the result generator of the resolution at `target`.
+            let hom_k = map.get_map(target.s()).hom_k(b.t());
+            for (j, row) in hom_k.iter().enumerate() {
+                for (k, &v) in row.iter().enumerate() {
+                    matrix.row_mut(j).add_basis_element(k, c * v);
+                }
+            }
+        }
+        Some(matrix)
+    }
+
+    /// The product `x · y` if it lies in the computed range, else `None`. See
+    /// [`multiply_into`](Self::multiply_into) for the operand conventions. The result lies in
+    /// bidegree `x.degree() + y.degree()`.
+    pub fn try_multiply(
+        &self,
+        x: &BidegreeElement,
+        y: &BidegreeElement,
+    ) -> Option<BidegreeElement> {
+        let target = x.degree() + y.degree();
+        let matrix = self.multiply_into(x, y.degree())?;
+        let mut out = FpVector::new(self.prime(), matrix.columns());
+        for (j, c) in y.vec().iter_nonzero() {
+            out.as_slice_mut().add(matrix.row(j), c);
+        }
+        Some(BidegreeElement::new(target, out))
+    }
+
+    /// The product `x · y`, where `x ∈ Ext(M, k)` and `y ∈ Ext(k, k)`. When `M == k` both operands
+    /// live in the same algebra $\Ext(k, k)$. The result lies in bidegree `x.degree() + y.degree()`.
+    ///
+    /// Panics if the product is out of the computed range; use
+    /// [`try_multiply`](Self::try_multiply) to handle that case.
+    pub fn multiply(&self, x: &BidegreeElement, y: &BidegreeElement) -> BidegreeElement {
+        self.try_multiply(x, y).expect(
+            "multiply: product is out of the computed range; compute further or use try_multiply",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::construct_standard;
+
+    #[test]
+    fn test_sphere_products() {
+        let res = Arc::new(construct_standard::<false, _, _>("S_2", None).unwrap());
+        res.compute_through_stem(Bidegree::n_s(8, 8));
+        let alg = ExtAlgebra::new(Arc::clone(&res), res);
+
+        // h_i live in Ext^{1, *}: h_0 = (n=0, s=1), h_1 = (n=1, s=1), h_2 = (n=3, s=1).
+        let h0 = alg.generator(BidegreeGenerator::new(Bidegree::n_s(0, 1), 0));
+        let h1 = alg.generator(BidegreeGenerator::new(Bidegree::n_s(1, 1), 0));
+
+        // h_0^2 is the nonzero generator of Ext^{2,2} = (n=0, s=2).
+        let h0_sq = alg.multiply(&h0, &h0);
+        assert_eq!(h0_sq.degree(), Bidegree::n_s(0, 2));
+        assert_eq!(alg.dimension(Bidegree::n_s(0, 2)), 1);
+        assert!(!h0_sq.vec().is_zero(), "h_0^2 should be nonzero");
+
+        // The Adams relations h_0 h_1 = 0 = h_1 h_0.
+        assert!(
+            alg.multiply(&h0, &h1).vec().is_zero(),
+            "h_0 h_1 should vanish"
+        );
+        assert!(
+            alg.multiply(&h1, &h0).vec().is_zero(),
+            "h_1 h_0 should vanish"
+        );
+
+        // Cross-check `multiply` against a direct `hom_k` read for h_0 · h_1.
+        let rows = alg
+            .multiply_into(&h0, h1.degree())
+            .expect("h_0 · h_1 is in range");
+        let direct: u32 = rows.row(0).iter().sum();
+        assert_eq!(direct, 0);
+    }
+}

--- a/ext/src/ext_algebra/mod.rs
+++ b/ext/src/ext_algebra/mod.rs
@@ -15,6 +15,11 @@
 //! computes the products of the multiplier with *all* classes of $\Ext(k, k)$. We cache one such
 //! map per *generator* of $\Ext(M, k)$ (keyed by [`BidegreeGenerator`]); a product by a general
 //! class is assembled at request time as the corresponding linear combination of generator maps.
+//!
+//! The secondary differential ($d_2$) and the $\Mod_{C\lambda^2}$ secondary product live in the
+//! [`secondary`] submodule ([`SecondaryExtAlgebra`](secondary::SecondaryExtAlgebra)).
+
+pub mod secondary;
 
 use std::sync::Arc;
 
@@ -69,6 +74,18 @@ impl<CC: FreeChainComplex> ExtAlgebra<CC> {
             unit,
             products: DashMap::new(),
         }
+    }
+
+    /// Build an [`ExtAlgebra`] for resolution-*intrinsic* operations that do not involve products
+    /// (notably the secondary `d2` differential), using the resolution itself in place of a unit.
+    ///
+    /// This avoids the unit-resolution setup (and any associated prompt) that
+    /// [`from_resolution`](Self::from_resolution) performs. The product methods
+    /// ([`multiply`](Self::multiply) etc.) and the unit-side queries are only meaningful here when
+    /// `M == k`; for products with `M != k`, build with [`from_resolution`](Self::from_resolution)
+    /// or [`new`](Self::new) instead.
+    pub fn without_unit(resolution: Arc<CC>) -> Self {
+        Self::new(Arc::clone(&resolution), resolution)
     }
 
     pub fn resolution(&self) -> &Arc<CC> {

--- a/ext/src/ext_algebra/secondary.rs
+++ b/ext/src/ext_algebra/secondary.rs
@@ -1,0 +1,310 @@
+//! The secondary ($d_2$) layer of [`ExtAlgebra`].
+//!
+//! [`SecondaryExtAlgebra`] composes an [`ExtAlgebra`] with the secondary resolutions of `M` and
+//! the unit `k`, and exposes:
+//! - the secondary differential [`d2`](SecondaryExtAlgebra::d2) (and the survival check
+//!   [`survives`](SecondaryExtAlgebra::survives)),
+//! - the $E_3$-page data [`page_data`](SecondaryExtAlgebra::page_data), and
+//! - the $\Mod_{C\lambda^2}$ secondary product
+//!   [`secondary_multiply_into`](SecondaryExtAlgebra::secondary_multiply_into).
+//!
+//! These wrap [`SecondaryResolution`] and [`SecondaryResolutionHomomorphism`]; no new linear
+//! algebra is implemented here. The layer is split out from [`ExtAlgebra`] because the secondary
+//! machinery requires `CC::Algebra: PairAlgebra`, a bound the primary layer does not impose.
+
+use std::sync::{Arc, Mutex};
+
+use algebra::pair_algebra::PairAlgebra;
+use dashmap::DashMap;
+use fp::{matrix::Subquotient, prime::Prime, vector::FpVector};
+use sseq::coordinates::{Bidegree, BidegreeElement};
+
+use super::ExtAlgebra;
+use crate::{
+    chain_complex::FreeChainComplex,
+    resolution_homomorphism::ResolutionHomomorphism,
+    secondary::{
+        LAMBDA_BIDEGREE, SecondaryLift, SecondaryResolution, SecondaryResolutionHomomorphism,
+    },
+};
+
+/// A single secondary product `x · y` in $\Mod_{C\lambda^2}$, where `y` is an $E_3$-surviving
+/// class. See [`SecondaryExtAlgebra::secondary_multiply_into`].
+pub struct SecondaryProduct {
+    /// The multiplicand: an $E_3$-surviving generator of the unit at the queried bidegree `b`.
+    pub source: BidegreeElement,
+    /// The $\Ext$ part of the product, in bidegree `b + x.degree()`.
+    pub ext_part: FpVector,
+    /// The $\lambda$ part of the product, in bidegree `b + x.degree() + LAMBDA_BIDEGREE`, already
+    /// reduced by the image of $d_2$.
+    pub lambda_part: FpVector,
+}
+
+/// The secondary layer over an [`ExtAlgebra`]: the $d_2$ differential and the $\Mod_{C\lambda^2}$
+/// product. See the [module documentation](self).
+pub struct SecondaryExtAlgebra<CC: FreeChainComplex>
+where
+    CC::Algebra: PairAlgebra,
+{
+    alg: Arc<ExtAlgebra<CC>>,
+    res_lift: Arc<SecondaryResolution<CC>>,
+    /// `Arc`-shared with `res_lift` when `M == k`.
+    unit_lift: Arc<SecondaryResolution<CC>>,
+    /// $E_3$ page of the resolution, filled by [`extend_all`](Self::extend_all).
+    res_sseq: Mutex<Option<Arc<sseq::Sseq<2, sseq::Adams>>>>,
+    /// $E_3$ page of the unit, filled by [`extend_all`](Self::extend_all).
+    unit_sseq: Mutex<Option<Arc<sseq::Sseq<2, sseq::Adams>>>>,
+    /// Secondary lift of the multiplication map, cached per multiplier class `(degree, coords)`.
+    secondary_products: DashMap<(Bidegree, Vec<u32>), Arc<SecondaryResolutionHomomorphism<CC, CC>>>,
+}
+
+impl<CC: FreeChainComplex> SecondaryExtAlgebra<CC>
+where
+    CC::Algebra: PairAlgebra,
+{
+    /// Build the secondary layer over `alg`. Construction is cheap; call [`extend_all`](Self::extend_all)
+    /// to actually compute the secondary resolutions and $E_3$ pages.
+    pub fn new(alg: Arc<ExtAlgebra<CC>>) -> Self {
+        let res_lift = Arc::new(SecondaryResolution::new(Arc::clone(alg.resolution())));
+        let unit_lift = if alg.is_unit() {
+            Arc::clone(&res_lift)
+        } else {
+            Arc::new(SecondaryResolution::new(Arc::clone(alg.unit())))
+        };
+        Self {
+            alg,
+            res_lift,
+            unit_lift,
+            res_sseq: Mutex::new(None),
+            unit_sseq: Mutex::new(None),
+            secondary_products: DashMap::new(),
+        }
+    }
+
+    /// Extend the secondary resolutions as far as the underlying resolutions allow, then compute
+    /// the $E_3$ pages. Must be called before [`d2`](Self::d2), [`page_data`](Self::page_data) or
+    /// [`secondary_multiply_into`](Self::secondary_multiply_into).
+    pub fn extend_all(&self) {
+        self.res_lift.extend_all();
+        if !self.alg.is_unit() {
+            self.unit_lift.extend_all();
+        }
+
+        *self.res_sseq.lock().unwrap() = Some(Arc::new(self.res_lift.e3_page()));
+        let unit = if self.alg.is_unit() {
+            Arc::clone(self.res_sseq.lock().unwrap().as_ref().unwrap())
+        } else {
+            Arc::new(self.unit_lift.e3_page())
+        };
+        *self.unit_sseq.lock().unwrap() = Some(unit);
+    }
+
+    /// Sharding entry point: compute only the secondary resolution data for filtration `s`,
+    /// distributed across machines sharing a save directory (see the `secondary` example docs).
+    /// Mirrors [`SecondaryLift::compute_partial`]. Returns before any $E_3$ page is built.
+    pub fn compute_partial(&self, s: i32) {
+        self.res_lift.compute_partial(s);
+        if !self.alg.is_unit() {
+            self.unit_lift.compute_partial(s);
+        }
+    }
+
+    /// The primary [`ExtAlgebra`] this is built on.
+    pub fn ext_algebra(&self) -> &Arc<ExtAlgebra<CC>> {
+        &self.alg
+    }
+
+    fn prime(&self) -> fp::prime::ValidPrime {
+        self.alg.prime()
+    }
+
+    /// The secondary differential $d_2(x)$, a class in bidegree `(n - 1, s + 2)`.
+    ///
+    /// Returns `None` if the target bidegree has not been computed (so $d_2$ is unknown). A
+    /// computed-but-zero differential is `Some` of a zero class.
+    pub fn d2(&self, x: &BidegreeElement) -> Option<BidegreeElement> {
+        let b = x.degree();
+        let target = b + Bidegree::n_s(-1, 2);
+        let res = self.res_lift.underlying();
+        if !(b.t() > 0 && res.has_computed_bidegree(target)) {
+            return None;
+        }
+
+        let target_dim = res.number_of_gens_in_bidegree(target);
+        let mut out = FpVector::new(self.prime(), target_dim);
+
+        // `m[i]` is the d2 of the i-th generator of `b`, as a vector at `target`. This is exactly
+        // the matrix `SecondaryResolution::e3_page` reads to install d2 differentials.
+        let m = self.res_lift.homotopy(b.s() + 2).homotopies.hom_k(b.t());
+        if !m.is_empty() && !m[0].is_empty() {
+            let p = self.prime().as_u32();
+            for (i, c) in x.vec().iter_nonzero() {
+                for (k, &v) in m[i].iter().enumerate() {
+                    out.add_basis_element(k, (c * v) % p);
+                }
+            }
+        }
+        Some(BidegreeElement::new(target, out))
+    }
+
+    /// Whether `x` is a $d_2$-cycle (a permanent class through $E_3$). Treats an uncomputed $d_2$
+    /// target as "survives" (there is nothing for it to hit).
+    pub fn survives(&self, x: &BidegreeElement) -> bool {
+        self.d2(x).is_none_or(|d| d.vec().is_zero())
+    }
+
+    /// The $E_3$-page subquotient of $\Ext(M, k)$ at bidegree `b`.
+    pub fn page_data(&self, b: Bidegree) -> Subquotient {
+        let g = self.res_sseq.lock().unwrap();
+        Self::e3_page_data(g.as_ref().expect("call extend_all() first"), b).clone()
+    }
+
+    /// The $E_3$-page subquotient of the unit $\Ext(k, k)$ at bidegree `b`.
+    pub fn unit_page_data(&self, b: Bidegree) -> Subquotient {
+        let g = self.unit_sseq.lock().unwrap();
+        Self::e3_page_data(g.as_ref().expect("call extend_all() first"), b).clone()
+    }
+
+    fn e3_page_data(sseq: &sseq::Sseq<2, sseq::Adams>, b: Bidegree) -> &Subquotient {
+        let d = sseq.page_data(b);
+        &d[std::cmp::min(3, d.len() - 1)]
+    }
+}
+
+impl<CC: FreeChainComplex + crate::chain_complex::AugmentedChainComplex> SecondaryExtAlgebra<CC>
+where
+    CC::Algebra: PairAlgebra,
+{
+    /// The secondary lift of multiplication by `x`, built and cached per multiplier class. The
+    /// returned lift is *not* extended; [`secondary_multiply_into`](Self::secondary_multiply_into)
+    /// extends it as needed. Exposed so callers can drive sharded computation
+    /// (`lift.underlying().extend_all()` then `lift.compute_partial(s)`).
+    pub fn secondary_product_lift(
+        &self,
+        x: &BidegreeElement,
+    ) -> Arc<SecondaryResolutionHomomorphism<CC, CC>> {
+        let shift = x.degree();
+        let coords: Vec<u32> = x.vec().iter().collect();
+        let key = (shift, coords.clone());
+
+        if let Some(map) = self.secondary_products.get(&key) {
+            return Arc::clone(&map);
+        }
+
+        let name = format!(
+            "prod_{}_{}_{}",
+            shift.n(),
+            shift.s(),
+            coords
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join("_")
+        );
+        let underlying = Arc::new(ResolutionHomomorphism::from_class(
+            name,
+            Arc::clone(self.alg.resolution()),
+            Arc::clone(self.alg.unit()),
+            shift,
+            &coords,
+        ));
+        let lift = Arc::new(SecondaryResolutionHomomorphism::new(
+            Arc::clone(&self.res_lift),
+            Arc::clone(&self.unit_lift),
+            underlying,
+        ));
+
+        Arc::clone(self.secondary_products.entry(key).or_insert(lift).value())
+    }
+
+    /// The secondary product of `x` with every $E_3$-surviving class of the unit at bidegree `b`,
+    /// computed in $\Mod_{C\lambda^2}$.
+    ///
+    /// Returns one [`SecondaryProduct`] per surviving generator at `b`; the $\lambda$ part is
+    /// already reduced by the image of $d_2$. The caller must have run [`extend_all`](Self::extend_all)
+    /// and computed both resolutions far enough.
+    pub fn secondary_multiply_into(
+        &self,
+        x: &BidegreeElement,
+        b: Bidegree,
+    ) -> Vec<SecondaryProduct> {
+        let p = self.prime();
+        let shift = x.degree();
+        let res_sseq = Arc::clone(
+            self.res_sseq
+                .lock()
+                .unwrap()
+                .as_ref()
+                .expect("call extend_all() first"),
+        );
+
+        let ext_dim = self.alg.resolution().number_of_gens_in_bidegree(b + shift);
+        let lambda_dim = self
+            .alg
+            .resolution()
+            .number_of_gens_in_bidegree(b + shift + LAMBDA_BIDEGREE);
+
+        let page = self.unit_page_data(b);
+        let n = page.subspace_dimension();
+        if n == 0 {
+            return Vec::new();
+        }
+
+        let lift = self.secondary_product_lift(x);
+        lift.underlying().extend_all();
+        lift.extend_all();
+
+        let mut outputs = vec![FpVector::new(p, ext_dim + lambda_dim); n];
+        lift.hom_k(
+            Some(&res_sseq),
+            b,
+            page.subspace_gens(),
+            outputs.iter_mut().map(FpVector::as_slice_mut),
+        );
+
+        page.subspace_gens()
+            .zip(outputs)
+            .map(|(g, out)| SecondaryProduct {
+                source: BidegreeElement::new(b, g.to_owned()),
+                ext_part: out.slice(0, ext_dim).to_owned(),
+                lambda_part: out.slice(ext_dim, ext_dim + lambda_dim).to_owned(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sseq::coordinates::BidegreeGenerator;
+
+    use super::*;
+    use crate::utils::construct_standard;
+
+    #[test]
+    fn test_sphere_d2() {
+        let res = Arc::new(construct_standard::<false, _, _>("S_2", None).unwrap());
+        // Far enough to reach the first Adams differential d2(h4) = h0 h3^2 at (14, 3).
+        res.compute_through_stem(Bidegree::n_s(16, 6));
+        let e2 = Arc::new(ExtAlgebra::new(Arc::clone(&res), res));
+        let sec_e2 = SecondaryExtAlgebra::new(Arc::clone(&e2));
+        sec_e2.extend_all();
+
+        // h_0, h_1, h_2 are permanent cycles.
+        for (n, s) in [(0, 1), (1, 1), (3, 1)] {
+            let h = e2.generator(BidegreeGenerator::new(Bidegree::n_s(n, s), 0));
+            assert!(sec_e2.survives(&h), "h at (n={n}, s={s}) should survive d2");
+            assert!(
+                sec_e2.d2(&h).is_none_or(|d| d.vec().is_zero()),
+                "d2 of a permanent class should vanish"
+            );
+        }
+
+        // The first Adams differential: d2(h4) = h0 h3^2, the generator of Ext^{3,17} at (14, 3).
+        let h4 = e2.generator(BidegreeGenerator::new(Bidegree::n_s(15, 1), 0));
+        let d = sec_e2.d2(&h4).expect("d2(h4) target should be computed");
+        assert_eq!(d.degree(), Bidegree::n_s(14, 3));
+        assert_eq!(e2.dimension(Bidegree::n_s(14, 3)), 1);
+        assert!(!d.vec().is_zero(), "d2(h4) = h0 h3^2 should be nonzero");
+        assert!(!sec_e2.survives(&h4), "h4 should not survive d2");
+    }
+}

--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -168,6 +168,7 @@
 #![deny(clippy::use_self, unsafe_op_in_unsafe_fn)]
 
 pub mod chain_complex;
+pub mod ext_algebra;
 pub mod resolution;
 pub mod resolution_homomorphism;
 pub mod save;


### PR DESCRIPTION
## Summary

Phase 2 of the bigraded-algebra layer: the **secondary differential**. Adds
`ext::ext_algebra::secondary::SecondaryExtAlgebra<CC>`, which composes the Phase 1
`ExtAlgebra` with the secondary resolutions of `M` and the unit `k` and exposes:

- **`d2(x)`** — the secondary differential, a class in bidegree `(n-1, s+2)`; and **`survives(x)`**, the permanent-cycle (d₂-cycle) check.
- **`page_data(b)` / `unit_page_data(b)`** — the $E_3$-page subquotient (promotes the `get_page_data` helper that was duplicated across the secondary examples).
- **`secondary_multiply_into(x, b)`** — the $\Mod_{C\lambda^2}$ secondary product of `x` with every $E_3$-surviving class at `b`, returned split into Ext part + λ part (already reduced by the image of d₂).

This is a thin orchestration layer over `SecondaryResolution` / `SecondaryResolutionHomomorphism` — no new linear algebra.

> Stacked on #8 (Phase 1). This PR targets the Phase 1 branch, so its diff is Phase 2 only; merge #8 first.

## Notable changes

- `ext_algebra.rs` becomes the module directory `ext_algebra/{mod,secondary}.rs`. The secondary layer is a sibling struct (not a field on `ExtAlgebra`) because `SecondaryResolution<CC>` requires `CC::Algebra: PairAlgebra`, a bound the primary layer deliberately avoids.
- `ExtAlgebra::without_unit(resolution)` — a unit-free constructor for resolution-intrinsic operations (the d₂ lister needs no unit, so this avoids the unit-setup prompt).
- `SecondaryExtAlgebra::compute_partial(s)` and the public `secondary_product_lift(x)` preserve the existing per-`s` **sharding** workflow.

## Examples refactored

- `secondary.rs` (d₂ lister) and `secondary_product.rs` now use the layer. Both produce **byte-identical output** to the pre-refactor versions (verified on `S_2`: the `secondary` output including `d_2 x_(15,1,0) = [1]`, i.e. $d_2(h_4)=h_0h_3^2$; and `[h0]`-products, 25 lines, exact match).

## Test plan

- [x] `cargo build -p ext` / `cargo clippy -p ext --examples` clean
- [x] `cargo test -p ext` — new `test_sphere_d2` asserts $d_2(h_4)=h_0h_3^2$ is nonzero and that $h_0,h_1,h_2$ are permanent
- [x] `cargo run --example secondary` / `--example secondary_product` diffed byte-for-byte against the originals on `S_2`

## Out of scope

Massey products (Phase 3) and secondary Massey (later Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYWcvWZPm3YJkVpCmeGYsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYWcvWZPm3YJkVpCmeGYsP)_