### PR TITLE
ExtAlgebra Phase 4: secondary Massey products

### DIFF
--- a/ext/examples/massey.rs
+++ b/ext/examples/massey.rs
@@ -5,49 +5,41 @@
 
 use std::sync::Arc;
 
-use ext::{
-    chain_complex::{ChainComplex, ChainHomotopy, FreeChainComplex},
-    resolution_homomorphism::ResolutionHomomorphism,
-};
-use fp::matrix::{AugmentedMatrix, Matrix};
-use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
+use ext::{chain_complex::ChainComplex, ext_algebra::ExtAlgebra};
+use sseq::coordinates::Bidegree;
 
 fn main() -> anyhow::Result<()> {
     ext::utils::init_logging()?;
 
     let resolution = Arc::new(ext::utils::query_module(None, true)?);
-    let p = resolution.prime();
-
-    let (is_unit, unit) = ext::utils::get_unit(Arc::clone(&resolution))?;
+    let alg = ExtAlgebra::from_resolution(Arc::clone(&resolution))?;
 
     eprintln!("\nComputing Massey products <a, b, ->");
     eprintln!("\nEnter a:");
 
-    let a = Bidegree::n_s(
+    let a_deg = Bidegree::n_s(
         query::raw("n of Ext class a", str::parse),
         query::raw("s of Ext class a", str::parse::<std::num::NonZeroI32>).get(),
     );
-
-    unit.compute_through_stem(a);
-
-    let a_class = query::vector("Input Ext class a", unit.number_of_gens_in_bidegree(a));
+    alg.unit().compute_through_stem(a_deg);
+    let a_class = query::vector("Input Ext class a", alg.unit_dimension(a_deg));
+    let a = alg.unit_element(a_deg, &a_class);
 
     eprintln!("\nEnter b:");
 
-    let b = Bidegree::n_s(
+    let b_deg = Bidegree::n_s(
         query::raw("n of Ext class b", str::parse),
         query::raw("s of Ext class b", str::parse::<std::num::NonZeroI32>).get(),
     );
+    alg.unit().compute_through_stem(b_deg);
+    let b_class = query::vector("Input Ext class b", alg.unit_dimension(b_deg));
+    let b = alg.unit_element(b_deg, &b_class);
 
-    unit.compute_through_stem(b);
+    // The Massey product shifts the bidegree by this amount.
+    let shift = a_deg + b_deg - Bidegree::s_t(1, 0);
 
-    let b_class = query::vector("Input Ext class b", unit.number_of_gens_in_bidegree(b));
-
-    // The Massey product shifts the bidegree by this amount
-    let shift = a + b - Bidegree::s_t(1, 0);
-
-    if !is_unit {
-        unit.compute_through_stem(shift);
+    if !alg.is_unit() {
+        alg.unit().compute_through_stem(shift);
     }
 
     if !resolution.has_computed_bidegree(shift + Bidegree::s_t(0, resolution.min_degree())) {
@@ -55,94 +47,12 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let b_hom = Arc::new(ResolutionHomomorphism::from_class(
-        String::new(),
-        Arc::clone(&unit),
-        Arc::clone(&unit),
-        b,
-        &b_class,
-    ));
-
-    b_hom.extend_through_stem(shift);
-
-    let offset_a = unit.module(a.s()).generator_offset(a.t(), a.t(), 0);
-    for c in resolution.iter_nonzero_stem() {
-        if !resolution.has_computed_bidegree(c + shift) {
-            continue;
-        }
-
-        let tot = c + shift;
-
-        let num_gens = resolution.number_of_gens_in_bidegree(c);
-        let product_num_gens = resolution.number_of_gens_in_bidegree(b + c);
-        let target_num_gens = resolution.number_of_gens_in_bidegree(tot);
-        if target_num_gens == 0 {
-            continue;
-        }
-
-        let mut answers = vec![vec![0; target_num_gens]; num_gens];
-        let mut product = AugmentedMatrix::<2>::new(p, num_gens, [product_num_gens, num_gens]);
-        product.segment(1, 1).add_identity();
-
-        let mut matrix = Matrix::new(p, num_gens, 1);
-        for (idx, answer_row) in answers.iter_mut().enumerate() {
-            let hom = Arc::new(ResolutionHomomorphism::new(
-                String::new(),
-                Arc::clone(&resolution),
-                Arc::clone(&unit),
-                c,
-            ));
-
-            matrix.row_mut(idx).set_entry(0, 1);
-            hom.extend_step(c, Some(&matrix));
-            matrix.row_mut(idx).set_entry(0, 0);
-
-            hom.extend_through_stem(tot);
-
-            let homotopy = ChainHomotopy::new(Arc::clone(&hom), Arc::clone(&b_hom));
-
-            homotopy.extend(tot);
-
-            let last = homotopy.homotopy(tot.s());
-            for (i, answer) in answer_row.iter_mut().enumerate() {
-                let output = last.output(tot.t(), i);
-                for (k, &v) in a_class.iter().enumerate() {
-                    if v != 0 {
-                        *answer += v * output.entry(offset_a + k);
-                    }
-                }
-            }
-
-            for (k, &v) in b_class.iter().enumerate() {
-                if v != 0 {
-                    let g = BidegreeGenerator::new(b, k);
-                    hom.act(product.row_mut(idx).slice_mut(0, product_num_gens), v, g);
-                }
-            }
-        }
-        product.row_reduce();
-        let kernel = product.compute_kernel();
-
-        for row in kernel.iter() {
-            let c_element = BidegreeElement::new(c, row.to_owned());
-            print!(
-                "<a, b, {c_string}> = [",
-                c_string = c_element.to_basis_string()
-            );
-
-            #[allow(clippy::needless_range_loop)]
-            for i in 0..target_num_gens {
-                let mut entry = 0;
-                for (j, v) in row.iter().enumerate() {
-                    entry += v * answers[j][i];
-                }
-                if i != 0 {
-                    print!(", ");
-                }
-                print!("{}", entry % p);
-            }
-            println!("]");
-        }
+    for (c, result) in alg.massey_family(&a, &b) {
+        let entries: Vec<u32> = result.representative.vec().iter().collect();
+        println!(
+            "<a, b, {c_string}> = {entries:?}",
+            c_string = c.to_basis_string()
+        );
     }
 
     Ok(())

--- a/ext/examples/product.rs
+++ b/ext/examples/product.rs
@@ -1,0 +1,45 @@
+//! Computes products in Ext by left-multiplication by a fixed class.
+//!
+//! The program asks for a module `M` and a class `x ∈ Ext(M, k)`. It then prints the products of
+//! `x` with every basis class of `Ext(k, k)` that lands in a computed bidegree.
+//!
+//! This is the primary (i.e. non-secondary) analogue of [`secondary_product`](../secondary_product),
+//! written against the [`ExtAlgebra`] abstraction so the plumbing stays out of the way.
+
+use std::sync::Arc;
+
+use ext::{chain_complex::FreeChainComplex, ext_algebra::ExtAlgebra, utils::query_module};
+use sseq::coordinates::Bidegree;
+
+fn main() -> anyhow::Result<()> {
+    ext::utils::init_logging()?;
+
+    let resolution = Arc::new(query_module(None, true)?);
+    let alg = ExtAlgebra::from_resolution(resolution)?;
+
+    let shift = Bidegree::n_s(
+        query::raw("n of Ext class", str::parse),
+        query::raw("s of Ext class", str::parse),
+    );
+
+    let dim = alg.dimension(shift);
+    if dim == 0 {
+        panic!("No classes in bidegree {shift}");
+    }
+    let v: Vec<u32> = query::vector("Input Ext class", dim);
+    let x = alg.element(shift, &v);
+
+    for b in alg.unit().iter_nonzero_stem() {
+        // `None` means `b + shift` is out of the computed range, so skip it.
+        let Some(rows) = alg.multiply_into(&x, b) else {
+            continue;
+        };
+        for (g, row) in alg.unit_basis(b).into_iter().zip(rows.iter()) {
+            let coords: Vec<u32> = row.iter().collect();
+            if coords.iter().any(|&c| c != 0) {
+                println!("x · x_{g} = {coords:?}");
+            }
+        }
+    }
+    Ok(())
+}

--- a/ext/examples/secondary.rs
+++ b/ext/examples/secondary.rs
@@ -50,41 +50,47 @@ use std::sync::Arc;
 use algebra::module::Module;
 use ext::{
     chain_complex::{ChainComplex, FreeChainComplex},
-    secondary::*,
+    ext_algebra::{ExtAlgebra, secondary::SecondaryExtAlgebra},
     utils::query_module,
 };
-use sseq::coordinates::{Bidegree, BidegreeGenerator};
+use sseq::coordinates::Bidegree;
 
 fn main() -> anyhow::Result<()> {
     ext::utils::init_logging()?;
 
     let resolution = Arc::new(query_module(Some(algebra::AlgebraType::Milnor), true)?);
 
-    let lift = SecondaryResolution::new(Arc::clone(&resolution));
+    // The d2 differential is intrinsic to the resolution and needs no unit, so we avoid the unit
+    // setup with `without_unit`.
+    let sec = SecondaryExtAlgebra::new(Arc::new(ExtAlgebra::without_unit(resolution)));
+
     if let Some(s) = ext::utils::secondary_job() {
-        lift.compute_partial(s);
+        sec.compute_partial(s);
         return Ok(());
     }
 
-    lift.extend_all();
+    sec.extend_all();
 
+    let alg = sec.ext_algebra();
     let d2_shift = Bidegree::n_s(-1, 2);
 
-    // Iterate through target of the d2
-    for b in lift.underlying().iter_nonzero_stem() {
+    // Iterate through the target of the d2, in the same order as before.
+    for b in alg.resolution().iter_nonzero_stem() {
         if b.s() < 3 {
             continue;
         }
 
-        if b.t() - 1 > resolution.module(b.s() - 2).max_computed_degree() {
+        // The source of the d2 must be computed (its degree may exceed what `module(b.s() - 2)`
+        // reaches when resolving through a stem).
+        if b.t() - 1 > alg.resolution().module(b.s() - 2).max_computed_degree() {
             continue;
         }
-        let homotopy = lift.homotopy(b.s());
-        let m = homotopy.homotopies.hom_k(b.t() - 1);
 
-        for (i, entry) in m.into_iter().enumerate() {
-            let source_gen = BidegreeGenerator::new(b - d2_shift, i);
-            println!("d_2 x_{source_gen} = {entry:?}");
+        for g in alg.basis(b - d2_shift) {
+            if let Some(dx) = sec.d2(&alg.generator(g)) {
+                let entry: Vec<u32> = dx.vec().iter().collect();
+                println!("d_2 x_{g} = {entry:?}");
+            }
         }
     }
 

--- a/ext/examples/secondary_massey.rs
+++ b/ext/examples/secondary_massey.rs
@@ -18,34 +18,28 @@
 
 use std::sync::Arc;
 
-use algebra::{module::Module, pair_algebra::PairAlgebra};
 use ext::{
-    chain_complex::{ChainComplex, ChainHomotopy, FreeChainComplex},
-    resolution_homomorphism::ResolutionHomomorphism,
-    secondary::*,
+    chain_complex::{ChainComplex, FreeChainComplex},
+    ext_algebra::{ExtAlgebra, secondary::SecondaryExtAlgebra},
+    secondary::LAMBDA_BIDEGREE,
     utils::{QueryModuleResolution, query_module},
 };
-use fp::{
-    matrix::{Matrix, Subspace},
-    vector::FpVector,
-};
+use fp::{prime::ValidPrime, vector::FpVector};
 use itertools::Itertools;
 use sseq::coordinates::{Bidegree, BidegreeElement};
 
-struct HomData {
+/// The result of prompting for one input class: its display name, the $\Ext$ part, and an optional
+/// $\lambda$ part (one filtration up).
+struct InputClass {
     name: String,
-    class: FpVector,
-    hom_lift: Arc<SecondaryResolutionHomomorphism<QueryModuleResolution, QueryModuleResolution>>,
-    lambda_part: Option<Arc<ResolutionHomomorphism<QueryModuleResolution, QueryModuleResolution>>>,
+    ext: BidegreeElement,
+    lambda: Option<BidegreeElement>,
 }
 
-fn get_hom(
-    name: &str,
-    source: Arc<SecondaryResolution<QueryModuleResolution>>,
-    target: Arc<SecondaryResolution<QueryModuleResolution>>,
-) -> HomData {
-    let p = source.prime();
-
+/// Prompt for an input class as in the original `get_hom`: the bidegree, the $\Ext$-part name and
+/// coordinates, then (if the bidegree above is nonempty) the $\lambda$-part name and coordinates.
+/// `source` is the resolution the class lives over.
+fn query_class(name: &str, source: &Arc<QueryModuleResolution>, p: ValidPrime) -> InputClass {
     let shift = Bidegree::n_s(
         query::raw(&format!("n of {name}"), str::parse),
         query::raw(&format!("s of {name}"), str::parse),
@@ -53,74 +47,53 @@ fn get_hom(
 
     let ext_name: String = query::raw(&format!("Name of Ext part of {name}"), str::parse);
 
-    source
-        .underlying()
-        .compute_through_stem(shift + LAMBDA_BIDEGREE);
+    source.compute_through_stem(shift + LAMBDA_BIDEGREE);
 
-    let hom = Arc::new(ResolutionHomomorphism::new(
-        ext_name.clone(),
-        source.underlying(),
-        target.underlying(),
-        shift,
-    ));
+    let num_gens = source.number_of_gens_in_bidegree(shift);
+    let num_lambda_gens = source.number_of_gens_in_bidegree(shift + LAMBDA_BIDEGREE);
 
-    let num_gens = source.underlying().number_of_gens_in_bidegree(shift);
-    let num_lambda_gens = hom
-        .source
-        .number_of_gens_in_bidegree(shift + LAMBDA_BIDEGREE);
-
-    let mut class = FpVector::new(p, num_gens + num_lambda_gens);
-
-    let mut matrix = Matrix::new(p, num_gens, 1);
-
-    if !hom.name().is_empty() {
-        if matrix.rows() == 0 {
+    let mut ext = FpVector::new(p, num_gens);
+    if !ext_name.is_empty() {
+        if num_gens == 0 {
             eprintln!("No classes in this bidegree");
         } else {
             let v: Vec<u32> = query::vector(&format!("Input Ext class {ext_name}"), num_gens);
             for (i, &x) in v.iter().enumerate() {
-                matrix.row_mut(i).set_entry(0, x);
-                class.set_entry(i, x);
+                ext.set_entry(i, x);
             }
         }
     }
 
-    hom.extend_step(shift, Some(&matrix));
-
-    let hom_lift = Arc::new(SecondaryResolutionHomomorphism::new(source, target, hom));
-
-    let lambda_part = if num_lambda_gens > 0 {
+    let (lambda_name, lambda) = if num_lambda_gens > 0 {
         let lambda_name: String = query::raw(&format!("Name of λ part of {name}"), str::parse);
         if lambda_name.is_empty() {
-            None
+            (String::new(), None)
         } else {
             let v = query::vector(&format!("Input Ext class {lambda_name}"), num_lambda_gens);
+            let mut lambda = FpVector::new(p, num_lambda_gens);
             for (i, &x) in v.iter().enumerate() {
-                class.set_entry(num_gens + i, x);
+                lambda.set_entry(i, x);
             }
-            Some(Arc::new(ResolutionHomomorphism::from_class(
+            (
                 lambda_name,
-                hom_lift.source(),
-                hom_lift.target(),
-                shift + LAMBDA_BIDEGREE,
-                &v,
-            )))
+                Some(BidegreeElement::new(shift + LAMBDA_BIDEGREE, lambda)),
+            )
         }
     } else {
-        None
+        (String::new(), None)
     };
 
-    let name = match (&*ext_name, lambda_part.as_ref().map_or("", |x| x.name())) {
+    let name = match (&*ext_name, &*lambda_name) {
         ("", "") => panic!("Do not compute zero Massey product"),
         ("", x) => format!("λ{x}"),
         (x, "") => format!("[{x}]"),
         (x, y) => format!("[{x}] + λ{y}"),
     };
-    HomData {
+
+    InputClass {
         name,
-        class,
-        hom_lift,
-        lambda_part,
+        ext: BidegreeElement::new(shift, ext),
+        lambda,
     }
 }
 
@@ -138,357 +111,64 @@ fn main() -> anyhow::Result<()> {
 
     let p = resolution.prime();
 
-    let res_lift = Arc::new(SecondaryResolution::new(Arc::clone(&resolution)));
-    let unit_lift = if is_unit {
-        Arc::clone(&res_lift)
-    } else {
-        let lift = SecondaryResolution::new(Arc::clone(&unit));
-        Arc::new(lift)
-    };
+    let alg = Arc::new(ExtAlgebra::new(
+        Arc::clone(&resolution),
+        Arc::clone(&unit),
+        is_unit,
+    ));
+    let sec = SecondaryExtAlgebra::new(Arc::clone(&alg));
 
-    let HomData {
-        name: a_name,
-        class: _,
-        hom_lift: a,
-        lambda_part: a_lambda,
-    } = get_hom("a", Arc::clone(&res_lift), Arc::clone(&unit_lift));
-    let HomData {
-        name: b_name,
-        class: b_class,
-        hom_lift: b,
-        lambda_part: b_lambda,
-    } = get_hom("b", Arc::clone(&unit_lift), Arc::clone(&unit_lift));
+    // `a` lives in Ext(M, k); `b` and the third factor live in Ext(k, k).
+    let a = query_class("a", &resolution, p);
+    let b = query_class("b", &unit, p);
 
-    let shift = Bidegree::s_t(
-        (a.underlying().shift + b.underlying().shift).s(),
-        (a.shift() + b.shift()).t(),
-    );
+    let a_name = &a.name;
+    let b_name = &b.name;
 
-    // Extend resolutions
-    if !is_unit {
-        let res_max = Bidegree::n_s(
-            resolution.module(0).max_computed_degree(),
-            resolution.next_homological_degree() - 1,
-        );
-        unit.compute_through_stem(res_max - a.underlying().shift);
-    }
-
-    if is_unit {
-        res_lift.extend_all();
-    } else {
-        maybe_rayon::join(|| res_lift.extend_all(), || unit_lift.extend_all());
-    }
-
-    // Now extend homomorphisms
-    maybe_rayon::scope(|s| {
-        s.spawn(|_| {
-            a.underlying().extend_all();
-            a.extend_all();
-        });
-        s.spawn(|_| {
-            b.underlying().extend_all();
-            b.extend_all();
-        });
-        if let Some(a_lambda) = &a_lambda {
-            s.spawn(|_| a_lambda.extend_all());
-        }
-        if let Some(b_lambda) = &b_lambda {
-            s.spawn(|_| b_lambda.extend_all());
-        }
-    });
-
-    let res_sseq = Arc::new(res_lift.e3_page());
-    let unit_sseq = if is_unit {
-        Arc::clone(&res_sseq)
-    } else {
-        Arc::new(res_lift.e3_page())
-    };
-
-    let b_shift = b.underlying().shift;
-
-    let chain_homotopy = Arc::new(ChainHomotopy::new(a.underlying(), b.underlying()));
-    chain_homotopy.initialize_homotopies((b_shift + a.underlying().shift).s());
-
-    // Compute first homotopy
-    {
-        let v = a.product_nullhomotopy(a_lambda.as_deref(), &res_sseq, b_shift, b_class.as_slice());
-        let homotopy = chain_homotopy.homotopy(b_shift.s() + a.underlying().shift.s() - 1);
-        let htpy_source = a.shift() + b_shift;
-        homotopy.extend_by_zero(htpy_source.t() - 1);
-        homotopy.add_generators_from_rows(
-            htpy_source.t(),
-            v.into_iter()
-                .map(|x| FpVector::from_slice(p, &[x]))
-                .collect(),
-        );
-    }
-
-    chain_homotopy.extend_all();
-
-    let ch_lift = SecondaryChainHomotopy::new(
-        Arc::clone(&a),
-        Arc::clone(&b),
-        a_lambda.clone(),
-        b_lambda.clone(),
-        Arc::clone(&chain_homotopy),
-    );
+    let massey = sec.secondary_massey(&a.ext, a.lambda.as_ref(), &b.ext, b.lambda.as_ref());
 
     if let Some(s) = ext::utils::secondary_job() {
-        ch_lift.compute_partial(s);
+        massey.compute_partial(s);
         return Ok(());
     }
 
-    ch_lift.extend_all();
+    massey.extend();
 
-    fn get_page_data(sseq: &sseq::Sseq<2, sseq::Adams>, b: Bidegree) -> &fp::matrix::Subquotient {
-        let d = sseq.page_data(b);
-        &d[std::cmp::min(3, d.len() - 1)]
-    }
-
-    let mut scratch0: Vec<u32> = Vec::new();
-    let mut scratch1 = FpVector::new(p, 0);
-
-    let h_0 = ch_lift.algebra().p_tilde();
-
-    // Iterate through the multiplicand
-    for c in unit.iter_stem() {
-        if !resolution.has_computed_bidegree(c + shift - Bidegree::s_t(2, 0))
-            || !resolution.has_computed_bidegree(c + shift + Bidegree::s_t(0, 1))
-        {
-            continue;
-        }
-
-        // Now read off the products
-        let source = c + shift - Bidegree::s_t(1, 0);
-
-        let source_num_gens = resolution.number_of_gens_in_bidegree(source);
-        let source_lambda_num_gens =
-            resolution.number_of_gens_in_bidegree(source + LAMBDA_BIDEGREE);
-
-        if source_num_gens + source_lambda_num_gens == 0 {
-            continue;
-        }
-
-        // We find the kernel of multiplication by b.
-        let target_num_gens = unit.number_of_gens_in_bidegree(c);
-        let target_lambda_num_gens = unit.number_of_gens_in_bidegree(c + LAMBDA_BIDEGREE);
-        let target_all_gens = target_num_gens + target_lambda_num_gens;
-
-        let prod_num_gens = unit.number_of_gens_in_bidegree(c + b_shift);
-        let prod_lambda_num_gens = unit.number_of_gens_in_bidegree(c + b_shift + LAMBDA_BIDEGREE);
-        let prod_all_gens = prod_num_gens + prod_lambda_num_gens;
-
-        let e3_kernel = {
-            let target_page_data = get_page_data(&unit_sseq, c);
-            let target_lambda_page_data = get_page_data(&unit_sseq, c + LAMBDA_BIDEGREE);
-            let product_lambda_page_data = get_page_data(&unit_sseq, c + b_shift + LAMBDA_BIDEGREE);
-
-            // We first compute elements whose product vanish mod lambda, and later see what the
-            // possible lifts are. We do it this way to avoid Z/p^2 problems
-
-            let e2_kernel: Subspace = {
-                let mut product_matrix = Matrix::new(
-                    p,
-                    target_page_data.subspace_dimension(),
-                    target_num_gens + prod_num_gens,
+    for r in massey.family() {
+        print!("<{a_name}, {b_name}, ");
+        let c = r.third_factor.degree();
+        let has_ext = {
+            if r.third_factor.vec().iter_nonzero().count() > 0 {
+                print!(
+                    "[{basis_string}]",
+                    basis_string = r.third_factor.to_basis_string()
                 );
-
-                let m0 = Matrix::from_vec(
-                    p,
-                    &b.underlying()
-                        .get_map(c.s() + b.underlying().shift.s())
-                        .hom_k(c.t()),
-                );
-                for (g, mut out) in target_page_data
-                    .subspace_gens()
-                    .zip_eq(product_matrix.iter_mut())
-                {
-                    out.slice_mut(prod_num_gens, prod_num_gens + target_num_gens)
-                        .add(g, 1);
-                    for (i, v) in g.iter_nonzero() {
-                        out.slice_mut(0, prod_num_gens).add(m0.row(i), v);
-                    }
-                }
-                product_matrix.row_reduce();
-                product_matrix.compute_kernel(prod_num_gens)
-            };
-
-            // Now compute the e3 kernel
-            {
-                // First add the lifts from Ext
-                let e2_ker_dim = e2_kernel.dimension();
-                let mut product_matrix = Matrix::new(
-                    p,
-                    e2_ker_dim + target_lambda_page_data.quotient_dimension(),
-                    target_all_gens + prod_all_gens,
-                );
-
-                b.hom_k_with(
-                    b_lambda.as_deref(),
-                    Some(&unit_sseq),
-                    c,
-                    e2_kernel.basis(),
-                    product_matrix
-                        .slice_mut(0, e2_ker_dim, 0, prod_all_gens)
-                        .iter_mut(),
-                );
-                for (v, mut t) in e2_kernel.basis().zip(product_matrix.iter_mut()) {
-                    t.slice_mut(prod_all_gens, prod_all_gens + target_num_gens)
-                        .assign(v);
-                }
-
-                // Now add the lambda multiples
-                let m = Matrix::from_vec(
-                    p,
-                    &b.underlying()
-                        .get_map(b_shift.s() + c.s() + 1)
-                        .hom_k(c.t() + 1),
-                );
-
-                let mut count = 0;
-                for (i, &v) in target_lambda_page_data.quotient_pivots().iter().enumerate() {
-                    if v >= 0 {
-                        continue;
-                    }
-                    let mut row = product_matrix.row_mut(e2_ker_dim + count as usize);
-                    row.add_basis_element(prod_all_gens + target_num_gens + i, 1);
-                    row.slice_mut(prod_num_gens, prod_all_gens).add(m.row(i), 1);
-                    product_lambda_page_data
-                        .reduce_by_quotient(row.slice_mut(prod_num_gens, prod_all_gens));
-                    count += 1;
-                }
-
-                product_matrix.row_reduce();
-                product_matrix.compute_kernel(prod_all_gens)
+                true
+            } else {
+                false
             }
         };
 
-        if e3_kernel.dimension() == 0 {
-            continue;
-        }
+        let num_entries = r.third_factor_lambda.iter_nonzero().count();
+        if num_entries > 0 {
+            if has_ext {
+                print!(" + ");
+            }
+            print!("λ");
 
-        let m0 = chain_homotopy.homotopy(source.s()).hom_k(c.t());
-        let mt = Matrix::from_vec(p, &chain_homotopy.homotopy(source.s() + 1).hom_k(c.t() + 1));
-        let m1 = Matrix::from_vec(
-            p,
-            &ch_lift.homotopies()[source.s() + 1].homotopies.hom_k(c.t()),
-        );
-        let mp = Matrix::from_vec(
-            p,
-            &resolution
-                .filtration_one_product(1, h_0, Bidegree::s_t(source.s(), c.t() + shift.t()))
-                .unwrap(),
-        );
-        let ma = a
-            .underlying()
-            .get_map(source.s())
-            .hom_k(c.t() + b_shift.t());
-        let mb = b.underlying().get_map(c.s() + b_shift.s()).hom_k(c.t());
-
-        for g in e3_kernel.iter() {
-            // Print name
-            {
-                print!("<{a_name}, {b_name}, ");
-                let has_ext = {
-                    let ext_part = g.restrict(0, target_num_gens);
-                    if ext_part.iter_nonzero().count() > 0 {
-                        print!(
-                            "[{basis_string}]",
-                            basis_string =
-                                BidegreeElement::new(c, ext_part.to_owned()).to_basis_string()
-                        );
-                        true
-                    } else {
-                        false
-                    }
-                };
-
-                let lambda_part = g.restrict(target_num_gens, target_all_gens);
-                let num_entries = lambda_part.iter_nonzero().count();
-                if num_entries > 0 {
-                    if has_ext {
-                        print!(" + ");
-                    }
-                    print!("λ");
-
-                    let basis_string = BidegreeElement::new(
-                        c + LAMBDA_BIDEGREE,
-                        g.restrict(target_num_gens, target_all_gens).to_owned(),
-                    )
+            let basis_string =
+                BidegreeElement::new(c + LAMBDA_BIDEGREE, r.third_factor_lambda.clone())
                     .to_basis_string();
-                    if num_entries == 1 {
-                        print!("{basis_string}",);
-                    } else {
-                        print!("({basis_string})",);
-                    }
-                }
-                print!("> = ±");
+            if num_entries == 1 {
+                print!("{basis_string}");
+            } else {
+                print!("({basis_string})");
             }
-
-            scratch0.clear();
-            scratch0.resize(source_num_gens, 0);
-            scratch1.set_scratch_vector_size(source_lambda_num_gens);
-
-            // First deal with the null-homotopy of ab
-            for (i, v) in g.restrict(0, target_num_gens).iter_nonzero() {
-                scratch0
-                    .iter_mut()
-                    .zip_eq(&m0[i])
-                    .for_each(|(a, b)| *a += v * b);
-                scratch1.as_slice_mut().add(m1.row(i), v);
-            }
-            for (i, v) in g.restrict(target_num_gens, target_all_gens).iter_nonzero() {
-                scratch1.as_slice_mut().add(mt.row(i), v);
-            }
-            // Now do the -1 part of the null-homotopy of bc.
-            {
-                let sign = p * p - 1;
-                let out = b.product_nullhomotopy(b_lambda.as_deref(), &unit_sseq, c, g);
-                for (i, v) in out.iter_nonzero() {
-                    scratch0
-                        .iter_mut()
-                        .zip_eq(&ma[i])
-                        .for_each(|(a, b)| *a += v * b * sign);
-                }
-            }
-
-            for (i, v) in scratch0.iter().enumerate() {
-                let extra = *v / p;
-                scratch1.as_slice_mut().add(mp.row(i), extra % p);
-            }
-
-            print!("[{}]", scratch0.iter().map(|x| *x % p).format(", "));
-
-            // Then deal with the rest of the null-homotopy of bc. This is just the null-homotopy of
-            // 2.
-            scratch0.clear();
-            scratch0.resize(prod_num_gens, 0);
-
-            for (i, v) in g.restrict(0, target_num_gens).iter_nonzero() {
-                scratch0
-                    .iter_mut()
-                    .zip_eq(&mb[i])
-                    .for_each(|(a, b)| *a += v * b);
-            }
-            for (i, v) in scratch0.iter().enumerate() {
-                let extra = (*v / p) % p;
-                if extra == 0 {
-                    continue;
-                }
-                for gen_idx in 0..source_lambda_num_gens {
-                    let m = a.underlying().get_map((source + LAMBDA_BIDEGREE).s());
-                    let dx = m.output((source + LAMBDA_BIDEGREE).t(), gen_idx);
-                    let idx = unit.module((c + shift).s()).operation_generator_to_index(
-                        1,
-                        h_0,
-                        (c + shift).t(),
-                        i,
-                    );
-                    scratch1.add_basis_element(gen_idx, dx.entry(idx));
-                }
-            }
-            println!(" + λ{scratch1}");
         }
+        print!("> = ±");
+
+        print!("[{}]", r.representative.vec().iter().format(", "));
+        println!(" + λ{}", r.representative_lambda);
     }
     Ok(())
 }

--- a/ext/examples/secondary_product.rs
+++ b/ext/examples/secondary_product.rs
@@ -25,111 +25,61 @@ use std::sync::Arc;
 use algebra::module::Module;
 use ext::{
     chain_complex::{ChainComplex, FreeChainComplex},
-    resolution_homomorphism::ResolutionHomomorphism,
-    secondary::*,
+    ext_algebra::{ExtAlgebra, secondary::SecondaryExtAlgebra},
+    secondary::{LAMBDA_BIDEGREE, SecondaryLift},
     utils::query_module,
 };
-use fp::{matrix::Matrix, prime::Prime, vector::FpVector};
-use itertools::Itertools;
-use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
+use sseq::coordinates::{Bidegree, BidegreeGenerator};
 
 fn main() -> anyhow::Result<()> {
     ext::utils::init_logging()?;
 
     let resolution = Arc::new(query_module(Some(algebra::AlgebraType::Milnor), true)?);
-
-    let (is_unit, unit) = ext::utils::get_unit(Arc::clone(&resolution))?;
-
-    let p = resolution.prime();
+    let alg = Arc::new(ExtAlgebra::from_resolution(Arc::clone(&resolution))?);
 
     let name: String = query::raw("Name of product", str::parse);
-
     let shift = Bidegree::n_s(
         query::raw(&format!("n of Ext class {name}"), str::parse),
         query::raw(&format!("s of Ext class {name}"), str::parse),
     );
 
-    let hom = ResolutionHomomorphism::new(name, Arc::clone(&resolution), Arc::clone(&unit), shift);
-
-    let mut matrix = Matrix::new(p, hom.source.number_of_gens_in_bidegree(shift), 1);
-
-    if matrix.rows() == 0 || matrix.columns() == 0 {
+    let dim = alg.dimension(shift);
+    if dim == 0 {
         panic!("No classes in this bidegree");
     }
-    let v: Vec<u32> = query::vector("Input ext class", matrix.rows());
-    for (i, &x) in v.iter().enumerate() {
-        matrix.row_mut(i).set_entry(0, x);
-    }
+    let v: Vec<u32> = query::vector("Input ext class", dim);
+    let x = alg.element(shift, &v);
 
-    if !is_unit {
+    // Ensure the unit is resolved far enough to support the products.
+    if !alg.is_unit() {
         let res_max = Bidegree::n_s(
             resolution.module(0).max_computed_degree(),
             resolution.next_homological_degree() - 1,
         );
-        unit.compute_through_stem(res_max - shift);
+        alg.unit().compute_through_stem(res_max - shift);
     }
 
-    hom.extend_step(shift, Some(&matrix));
-    hom.extend_all();
+    let sec = Arc::new(SecondaryExtAlgebra::new(Arc::clone(&alg)));
+    sec.extend_all();
 
-    let res_lift = SecondaryResolution::new(Arc::clone(&resolution));
-    res_lift.extend_all();
+    // Check that the class survives to E3 (supports no d2).
+    assert!(sec.survives(&x), "Class supports a non-zero d2");
 
-    // Check that class survives to E3.
-    {
-        let m = res_lift.homotopy(shift.s() + 2).homotopies.hom_k(shift.t());
-        assert_eq!(m.len(), v.len());
-        let mut sum = vec![0; m[0].len()];
-        for (x, d2) in v.iter().zip_eq(&m) {
-            sum.iter_mut().zip_eq(d2).for_each(|(a, b)| *a += x * b);
-        }
-        assert!(
-            sum.iter().all(|x| x.is_multiple_of(p.as_u32())),
-            "Class supports a non-zero d2"
-        );
-    }
-    let res_lift = Arc::new(res_lift);
-
-    let unit_lift = if is_unit {
-        Arc::clone(&res_lift)
-    } else {
-        let lift = SecondaryResolution::new(Arc::clone(&unit));
-        lift.extend_all();
-        Arc::new(lift)
-    };
-
-    let hom = Arc::new(hom);
-    let hom_lift = SecondaryResolutionHomomorphism::new(
-        Arc::clone(&res_lift),
-        Arc::clone(&unit_lift),
-        Arc::clone(&hom),
-    );
+    let lift = sec.secondary_product_lift(&x);
 
     if let Some(s) = ext::utils::secondary_job() {
-        hom_lift.compute_partial(s);
+        lift.underlying().extend_all();
+        lift.compute_partial(s);
         return Ok(());
     }
 
-    hom_lift.extend_all();
+    // `x` multiplies on the left; the printed name is bracketed as in the original output.
+    let disp = format!("[{name}]");
 
-    // Compute E3 page
-    let res_sseq = Arc::new(res_lift.e3_page());
-    let unit_sseq = if is_unit {
-        Arc::clone(&res_sseq)
-    } else {
-        Arc::new(unit_lift.e3_page())
-    };
-
-    fn get_page_data(sseq: &sseq::Sseq<2, sseq::Adams>, b: Bidegree) -> &fp::matrix::Subquotient {
-        let d = sseq.page_data(b);
-        &d[std::cmp::min(3, d.len() - 1)]
-    }
-
-    let name = hom_lift.name();
-    // Iterate through the multiplicand
-    for b in unit.iter_nonzero_stem() {
-        // The potential target has to be hit, and we need to have computed (the data need for) the
-        // d2 that hits the potential target.
+    // Iterate through the multiplicand.
+    for b in alg.unit().iter_nonzero_stem() {
+        // The potential target has to be hit, and we need to have computed (the data needed for)
+        // the d2 that hits the potential target.
         if !resolution.has_computed_bidegree(b + shift + LAMBDA_BIDEGREE) {
             continue;
         }
@@ -137,48 +87,36 @@ fn main() -> anyhow::Result<()> {
             continue;
         }
 
-        let page_data = get_page_data(unit_sseq.as_ref(), b);
-
-        let target_num_gens = resolution.number_of_gens_in_bidegree(b + shift);
-        let lambda_num_gens = resolution.number_of_gens_in_bidegree(b + shift + LAMBDA_BIDEGREE);
-
+        let target_num_gens = alg.dimension(b + shift);
+        let lambda_num_gens = alg.dimension(b + shift + LAMBDA_BIDEGREE);
         if target_num_gens == 0 && lambda_num_gens == 0 {
             continue;
         }
 
-        // First print the products with non-surviving classes
-        if target_num_gens > 0 {
-            let hom_k = hom.get_map((b + shift).s()).hom_k(b.t());
-            for i in page_data.complement_pivots() {
+        let page = sec.unit_page_data(b);
+
+        // First the products with non-surviving classes: these are just λ times the (primary)
+        // product, read off the multiplication map.
+        if target_num_gens > 0
+            && let Some(rows) = alg.multiply_into(&x, b)
+        {
+            for i in page.complement_pivots() {
                 let g = BidegreeGenerator::new(b, i);
-                println!("{name} λ x_{g} = λ {:?}", hom_k[i]);
+                let entry: Vec<u32> = rows.row(i).iter().collect();
+                println!("{disp} λ x_{g} = λ {entry:?}");
             }
         }
 
-        // Now print the secondary products
-        if page_data.subspace_dimension() == 0 {
-            continue;
-        }
-
-        let mut outputs = vec![
-            FpVector::new(p, target_num_gens + lambda_num_gens);
-            page_data.subspace_dimension()
-        ];
-
-        hom_lift.hom_k(
-            Some(&res_sseq),
-            b,
-            page_data.subspace_gens(),
-            outputs.iter_mut().map(FpVector::as_slice_mut),
-        );
-        for (g, output) in page_data.subspace_gens().zip_eq(outputs) {
+        // Now the genuinely secondary products with surviving classes.
+        for prod in sec.secondary_multiply_into(&x, b) {
             println!(
-                "{name} [{basis_string}] = {} + λ {}",
-                output.slice(0, target_num_gens),
-                output.slice(target_num_gens, target_num_gens + lambda_num_gens),
-                basis_string = BidegreeElement::new(b, g.to_owned()).to_basis_string(),
+                "{disp} [{basis}] = {ext} + λ {lambda}",
+                basis = prod.source.to_basis_string(),
+                ext = prod.ext_part.as_slice(),
+                lambda = prod.lambda_part.as_slice(),
             );
         }
     }
+
     Ok(())
 }

--- a/ext/src/ext_algebra.rs
+++ b/ext/src/ext_algebra.rs
@@ -1,0 +1,273 @@
+//! A bigraded-algebra view of a resolution.
+//!
+//! [`ExtAlgebra`] wraps a resolution of a module `M` together with the resolution of the base
+//! field `k` (the "unit"), and presents $\Ext(M, k)$ as a bigraded module over the bigraded
+//! algebra $\Ext(k, k)$. When `M == k` this is the algebra $\Ext(k, k)$ itself.
+//!
+//! The goal is ergonomics: computing a product of Ext classes is a single [`ExtAlgebra::multiply`]
+//! call instead of the manual [`ResolutionHomomorphism`] + `extend` + `hom_k` plumbing that the
+//! examples currently re-derive. This is the foundational layer; the secondary differential ($d_2$)
+//! and Massey products are planned follow-ups.
+//!
+//! # Conventions
+//! A product is realised by a [`ResolutionHomomorphism`] built from a fixed multiplier class living
+//! in $\Ext(M, k)$ (source = resolution of `M`, target = resolution of `k`). That single chain map
+//! computes the products of the multiplier with *all* classes of $\Ext(k, k)$. We cache one such
+//! map per *generator* of $\Ext(M, k)$ (keyed by [`BidegreeGenerator`]); a product by a general
+//! class is assembled at request time as the corresponding linear combination of generator maps.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use fp::{matrix::Matrix, prime::ValidPrime, vector::FpVector};
+use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
+
+use crate::{
+    chain_complex::{AugmentedChainComplex, FreeChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+    utils::{QueryModuleResolution, get_unit},
+};
+
+/// $\Ext(M, k)$ as a bigraded module over the bigraded algebra $\Ext(k, k)$, backed by a
+/// resolution. See the [module-level documentation](self) for conventions.
+pub struct ExtAlgebra<CC: FreeChainComplex> {
+    /// Resolution of `M`; products land in its Ext.
+    resolution: Arc<CC>,
+    /// Resolution of the base field `k`. `Arc`-shared with `resolution` when `M == k`.
+    unit: Arc<CC>,
+    is_unit: bool,
+    /// One multiplication map per generator of $\Ext(M, k)$, built and extended on demand.
+    products: DashMap<BidegreeGenerator, Arc<ResolutionHomomorphism<CC, CC>>>,
+}
+
+impl ExtAlgebra<QueryModuleResolution> {
+    /// Build an [`ExtAlgebra`] from a resolution, deriving the unit via [`get_unit`].
+    ///
+    /// This may prompt for the unit's save directory when `M != k` (see [`get_unit`]); for a fully
+    /// non-interactive setup, use [`ExtAlgebra::new`] with an explicit unit instead.
+    pub fn from_resolution(resolution: Arc<QueryModuleResolution>) -> anyhow::Result<Self> {
+        let (is_unit, unit) = get_unit(Arc::clone(&resolution))?;
+        Ok(Self::new(resolution, unit, is_unit))
+    }
+
+    /// Ensure both the resolution and the unit are computed through the given stem.
+    pub fn compute_through_stem(&self, max: Bidegree) {
+        self.unit.compute_through_stem(max);
+        if !self.is_unit {
+            self.resolution.compute_through_stem(max);
+        }
+    }
+}
+
+impl<CC: FreeChainComplex> ExtAlgebra<CC> {
+    /// Build an [`ExtAlgebra`] from an explicit `(resolution, unit)` pair. Pass `is_unit = true`
+    /// (and the same `Arc` for both) exactly when `M == k`.
+    pub fn new(resolution: Arc<CC>, unit: Arc<CC>, is_unit: bool) -> Self {
+        Self {
+            resolution,
+            unit,
+            is_unit,
+            products: DashMap::new(),
+        }
+    }
+
+    pub fn resolution(&self) -> &Arc<CC> {
+        &self.resolution
+    }
+
+    pub fn unit(&self) -> &Arc<CC> {
+        &self.unit
+    }
+
+    pub fn is_unit(&self) -> bool {
+        self.is_unit
+    }
+
+    pub fn prime(&self) -> ValidPrime {
+        self.resolution.prime()
+    }
+
+    /// Ensure both the resolution and the unit are computed through the given bidegree.
+    pub fn compute_through_bidegree(&self, b: Bidegree) {
+        self.unit.compute_through_bidegree(b);
+        if !self.is_unit {
+            self.resolution.compute_through_bidegree(b);
+        }
+    }
+
+    /// The dimension of $\Ext^{s,t}(M, k)$ at the given bidegree.
+    pub fn dimension(&self, b: Bidegree) -> usize {
+        self.resolution.number_of_gens_in_bidegree(b)
+    }
+
+    /// The basis generators of $\Ext(M, k)$ at the given bidegree.
+    pub fn basis(&self, b: Bidegree) -> Vec<BidegreeGenerator> {
+        (0..self.dimension(b))
+            .map(|i| BidegreeGenerator::new(b, i))
+            .collect()
+    }
+
+    /// A class in $\Ext(M, k)$ from its coordinates in the generator basis at bidegree `b`.
+    pub fn element(&self, b: Bidegree, coords: &[u32]) -> BidegreeElement {
+        BidegreeElement::new(b, FpVector::from_slice(self.prime(), coords))
+    }
+
+    /// A single generator of $\Ext(M, k)$ as a class.
+    pub fn generator(&self, g: BidegreeGenerator) -> BidegreeElement {
+        g.into_element(self.prime(), self.dimension(g.degree()))
+    }
+
+    /// The dimension of $\Ext(k, k)$ at the given bidegree (the multiplicand/"scalar" side).
+    pub fn unit_dimension(&self, b: Bidegree) -> usize {
+        self.unit.number_of_gens_in_bidegree(b)
+    }
+
+    /// The basis generators of $\Ext(k, k)$ at the given bidegree.
+    pub fn unit_basis(&self, b: Bidegree) -> Vec<BidegreeGenerator> {
+        (0..self.unit_dimension(b))
+            .map(|i| BidegreeGenerator::new(b, i))
+            .collect()
+    }
+
+    /// A class in $\Ext(k, k)$ from its coordinates in the generator basis at bidegree `b`.
+    pub fn unit_element(&self, b: Bidegree, coords: &[u32]) -> BidegreeElement {
+        BidegreeElement::new(b, FpVector::from_slice(self.prime(), coords))
+    }
+}
+
+impl<CC> ExtAlgebra<CC>
+where
+    CC: FreeChainComplex + AugmentedChainComplex,
+{
+    /// The multiplication map for a single generator `g` of $\Ext(M, k)$, built and cached on
+    /// first use. The returned map is *not* guaranteed to be extended; [`ExtAlgebra::multiply_into`]
+    /// extends it as needed.
+    pub fn generator_product_map(
+        &self,
+        g: BidegreeGenerator,
+    ) -> Arc<ResolutionHomomorphism<CC, CC>> {
+        if let Some(map) = self.products.get(&g) {
+            return Arc::clone(&map);
+        }
+
+        let dim = self.resolution.number_of_gens_in_bidegree(g.degree());
+        let mut class = vec![0u32; dim];
+        class[g.idx()] = 1;
+
+        let name = format!("prod_{}_{}_{}", g.n(), g.s(), g.idx());
+        let hom = Arc::new(ResolutionHomomorphism::from_class(
+            name,
+            Arc::clone(&self.resolution),
+            Arc::clone(&self.unit),
+            g.degree(),
+            &class,
+        ));
+
+        Arc::clone(self.products.entry(g).or_insert(hom).value())
+    }
+
+    /// Left-multiplication by the class `x` (in $\Ext(M, k)$), applied to every basis generator of
+    /// $\Ext(k, k)$ at bidegree `b`.
+    ///
+    /// Returns `None` when the product is out of the computed range — that is, when `b` or
+    /// `b + x.degree()` has not been resolved — so callers never mistake an uncomputed product for a
+    /// zero one. Otherwise returns a matrix with one row per generator of $\Ext(k, k)$ at `b`; row
+    /// `j` is the product `x · g_j` expressed in the generator basis of $\Ext(M, k)$ at bidegree
+    /// `b + x.degree()`. A computed-but-empty bidegree yields a valid zero-dimension matrix, not
+    /// `None`.
+    pub fn multiply_into(&self, x: &BidegreeElement, b: Bidegree) -> Option<Matrix> {
+        let shift = x.degree();
+        let target = b + shift;
+
+        if !self.unit.has_computed_bidegree(b) || !self.resolution.has_computed_bidegree(target) {
+            return None;
+        }
+
+        let unit_dim = self.unit.number_of_gens_in_bidegree(b);
+        let res_dim = self.resolution.number_of_gens_in_bidegree(target);
+        let mut matrix = Matrix::new(self.prime(), unit_dim, res_dim);
+
+        for (i, c) in x.vec().iter_nonzero() {
+            let map = self.generator_product_map(BidegreeGenerator::new(shift, i));
+            map.extend_all();
+
+            // `hom_k(b.t())[j][k]`: `j` indexes the multiplicand generator of the unit at `b`, `k`
+            // indexes the result generator of the resolution at `target`.
+            let hom_k = map.get_map(target.s()).hom_k(b.t());
+            for (j, row) in hom_k.iter().enumerate() {
+                for (k, &v) in row.iter().enumerate() {
+                    matrix.row_mut(j).add_basis_element(k, c * v);
+                }
+            }
+        }
+        Some(matrix)
+    }
+
+    /// The product `x · y` if it lies in the computed range, else `None`. See
+    /// [`multiply_into`](Self::multiply_into) for the operand conventions. The result lies in
+    /// bidegree `x.degree() + y.degree()`.
+    pub fn try_multiply(
+        &self,
+        x: &BidegreeElement,
+        y: &BidegreeElement,
+    ) -> Option<BidegreeElement> {
+        let target = x.degree() + y.degree();
+        let matrix = self.multiply_into(x, y.degree())?;
+        let mut out = FpVector::new(self.prime(), matrix.columns());
+        for (j, c) in y.vec().iter_nonzero() {
+            out.as_slice_mut().add(matrix.row(j), c);
+        }
+        Some(BidegreeElement::new(target, out))
+    }
+
+    /// The product `x · y`, where `x ∈ Ext(M, k)` and `y ∈ Ext(k, k)`. When `M == k` both operands
+    /// live in the same algebra $\Ext(k, k)$. The result lies in bidegree `x.degree() + y.degree()`.
+    ///
+    /// Panics if the product is out of the computed range; use
+    /// [`try_multiply`](Self::try_multiply) to handle that case.
+    pub fn multiply(&self, x: &BidegreeElement, y: &BidegreeElement) -> BidegreeElement {
+        self.try_multiply(x, y).expect(
+            "multiply: product is out of the computed range; compute further or use try_multiply",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::construct_standard;
+
+    #[test]
+    fn test_sphere_products() {
+        let res = Arc::new(construct_standard::<false, _, _>("S_2", None).unwrap());
+        res.compute_through_stem(Bidegree::n_s(8, 8));
+        let alg = ExtAlgebra::new(Arc::clone(&res), res, true);
+
+        // h_i live in Ext^{1, *}: h_0 = (n=0, s=1), h_1 = (n=1, s=1), h_2 = (n=3, s=1).
+        let h0 = alg.generator(BidegreeGenerator::new(Bidegree::n_s(0, 1), 0));
+        let h1 = alg.generator(BidegreeGenerator::new(Bidegree::n_s(1, 1), 0));
+
+        // h_0^2 is the nonzero generator of Ext^{2,2} = (n=0, s=2).
+        let h0_sq = alg.multiply(&h0, &h0);
+        assert_eq!(h0_sq.degree(), Bidegree::n_s(0, 2));
+        assert_eq!(alg.dimension(Bidegree::n_s(0, 2)), 1);
+        assert!(!h0_sq.vec().is_zero(), "h_0^2 should be nonzero");
+
+        // The Adams relations h_0 h_1 = 0 = h_1 h_0.
+        assert!(
+            alg.multiply(&h0, &h1).vec().is_zero(),
+            "h_0 h_1 should vanish"
+        );
+        assert!(
+            alg.multiply(&h1, &h0).vec().is_zero(),
+            "h_1 h_0 should vanish"
+        );
+
+        // Cross-check `multiply` against a direct `hom_k` read for h_0 · h_1.
+        let rows = alg
+            .multiply_into(&h0, h1.degree())
+            .expect("h_0 · h_1 is in range");
+        let direct: u32 = rows.row(0).iter().sum();
+        assert_eq!(direct, 0);
+    }
+}

--- a/ext/src/ext_algebra/massey.rs
+++ b/ext/src/ext_algebra/massey.rs
@@ -1,0 +1,311 @@
+//! Primary Massey products in $\Ext$.
+//!
+//! [`ExtAlgebra::massey`] computes a triple Massey product $\langle a, b, c\rangle$, and
+//! [`ExtAlgebra::massey_family`] computes $\langle a, b, -\rangle$ for fixed $a, b$ and every valid
+//! third factor at once (the optimized form). Both wrap [`ChainHomotopy`]: for each candidate `c`
+//! we lift the multiplication map, build the null-homotopy of the composite with `b`, and read off
+//! the bracket by pairing with `a`. The valid `c` (those with `b · c = 0`) are exactly the kernel
+//! of multiplication by `b`.
+//!
+//! The result is a coset representative together with the indeterminacy
+//! $a \cdot \Ext + \Ext \cdot c$. The indeterminacy is computed when `M == k` (so both terms live
+//! in the same algebra); otherwise it is reported as the zero subspace. This matches (and reuses
+//! the logic of) the `massey` example, which computes the products up to a sign.
+
+use std::sync::Arc;
+
+use fp::{
+    matrix::{AugmentedMatrix, Matrix, Subspace},
+    vector::{FpSlice, FpVector},
+};
+use sseq::coordinates::{Bidegree, BidegreeElement, BidegreeGenerator};
+
+use super::ExtAlgebra;
+use crate::{
+    chain_complex::{AugmentedChainComplex, ChainHomotopy, FreeChainComplex},
+    resolution_homomorphism::ResolutionHomomorphism,
+};
+
+/// The result of a Massey product computation: a coset representative together with the
+/// indeterminacy subspace.
+pub struct MasseyResult {
+    /// A representative of the Massey product, in bidegree
+    /// `a.degree() + b.degree() + c.degree() - (1, 0)`.
+    pub representative: BidegreeElement,
+    /// The indeterminacy $a \cdot \Ext + \Ext \cdot c$, as a subspace of the bracket's bidegree.
+    /// Only populated when `M == k`; the zero subspace otherwise.
+    pub indeterminacy: Subspace,
+}
+
+impl<CC> ExtAlgebra<CC>
+where
+    CC: FreeChainComplex + AugmentedChainComplex,
+{
+    /// The bidegree shift of $\langle a, b, -\rangle$: a class `c` produces a bracket in bidegree
+    /// `c.degree() + a.degree() + b.degree() - (1, 0)`.
+    fn massey_shift(a: &BidegreeElement, b: &BidegreeElement) -> Bidegree {
+        a.degree() + b.degree() - Bidegree::s_t(1, 0)
+    }
+
+    /// The multiplication-by-`b` chain map (in the unit), extended far enough for brackets landing
+    /// at `shift`.
+    fn massey_b_hom(
+        &self,
+        b: &BidegreeElement,
+        shift: Bidegree,
+    ) -> Arc<ResolutionHomomorphism<CC, CC>> {
+        let b_coords: Vec<u32> = b.vec().iter().collect();
+        let hom = Arc::new(ResolutionHomomorphism::from_class(
+            String::new(),
+            Arc::clone(self.unit()),
+            Arc::clone(self.unit()),
+            b.degree(),
+            &b_coords,
+        ));
+        hom.extend_through_stem(shift);
+        hom
+    }
+
+    /// Compute, for a single multiplicand bidegree `c_deg`, the per-generator bracket values
+    /// `answers[gen][i]` and the kernel of multiplication by `b` (the valid third factors). Returns
+    /// `None` if the bracket bidegree is empty or uncomputed.
+    fn massey_at(
+        &self,
+        a: &BidegreeElement,
+        b: &BidegreeElement,
+        b_hom: &Arc<ResolutionHomomorphism<CC, CC>>,
+        shift: Bidegree,
+        offset_a: usize,
+        c_deg: Bidegree,
+    ) -> Option<(Vec<Vec<u32>>, Subspace, Bidegree)> {
+        let p = self.prime();
+        let resolution = self.resolution();
+        let unit = self.unit();
+
+        if !resolution.has_computed_bidegree(c_deg + shift) {
+            return None;
+        }
+        let tot = c_deg + shift;
+
+        let num_gens = resolution.number_of_gens_in_bidegree(c_deg);
+        let product_num_gens = resolution.number_of_gens_in_bidegree(b.degree() + c_deg);
+        let target_num_gens = resolution.number_of_gens_in_bidegree(tot);
+        if target_num_gens == 0 {
+            return None;
+        }
+
+        let a_coords: Vec<u32> = a.vec().iter().collect();
+        let b_coords: Vec<u32> = b.vec().iter().collect();
+
+        let mut answers = vec![vec![0u32; target_num_gens]; num_gens];
+        let mut product = AugmentedMatrix::<2>::new(p, num_gens, [product_num_gens, num_gens]);
+        product.segment(1, 1).add_identity();
+
+        let mut matrix = Matrix::new(p, num_gens, 1);
+        for (idx, answer_row) in answers.iter_mut().enumerate() {
+            let hom = Arc::new(ResolutionHomomorphism::new(
+                String::new(),
+                Arc::clone(resolution),
+                Arc::clone(unit),
+                c_deg,
+            ));
+
+            matrix.row_mut(idx).set_entry(0, 1);
+            hom.extend_step(c_deg, Some(&matrix));
+            matrix.row_mut(idx).set_entry(0, 0);
+
+            hom.extend_through_stem(tot);
+
+            let homotopy = ChainHomotopy::new(Arc::clone(&hom), Arc::clone(b_hom));
+            homotopy.extend(tot);
+
+            let last = homotopy.homotopy(tot.s());
+            for (i, answer) in answer_row.iter_mut().enumerate() {
+                let output = last.output(tot.t(), i);
+                for (k, &val) in a_coords.iter().enumerate() {
+                    if val != 0 {
+                        *answer += val * output.entry(offset_a + k);
+                    }
+                }
+            }
+
+            for (k, &val) in b_coords.iter().enumerate() {
+                if val != 0 {
+                    let g = BidegreeGenerator::new(b.degree(), k);
+                    hom.act(product.row_mut(idx).slice_mut(0, product_num_gens), val, g);
+                }
+            }
+        }
+        product.row_reduce();
+        let kernel = product.compute_kernel();
+
+        Some((answers, kernel, tot))
+    }
+
+    /// Contract the per-generator bracket values `answers` against the coordinates `row` of a
+    /// third factor, producing the bracket representative at `tot`.
+    fn massey_contract(
+        &self,
+        answers: &[Vec<u32>],
+        row: FpSlice,
+        tot: Bidegree,
+    ) -> BidegreeElement {
+        let p = self.prime();
+        let target_num_gens = answers.first().map_or(0, Vec::len);
+        let mut v = FpVector::new(p, target_num_gens);
+        for (j, val) in row.iter().enumerate() {
+            if val != 0 {
+                for (i, a) in answers[j].iter().enumerate() {
+                    v.add_basis_element(i, val * a);
+                }
+            }
+        }
+        BidegreeElement::new(tot, v)
+    }
+
+    /// The indeterminacy $a \cdot \Ext^{|b| + |c| - (1,0)} + \Ext^{|a| + |b| - (1,0)} \cdot c$ at
+    /// the bracket bidegree `tot`. Computed only when `M == k`; otherwise the zero subspace.
+    fn massey_indeterminacy(
+        &self,
+        a: &BidegreeElement,
+        c: &BidegreeElement,
+        tot: Bidegree,
+    ) -> Subspace {
+        let mut sub = Subspace::new(self.prime(), self.dimension(tot));
+        if !self.is_unit() {
+            return sub;
+        }
+
+        // a · Ext^{tot - a.degree()}
+        for y in self.basis(tot - a.degree()) {
+            if let Some(prod) = self.try_multiply(a, &self.generator(y)) {
+                sub.add_vector(prod.vec());
+            }
+        }
+        // Ext^{tot - c.degree()} · c
+        for x in self.basis(tot - c.degree()) {
+            if let Some(prod) = self.try_multiply(&self.generator(x), c) {
+                sub.add_vector(prod.vec());
+            }
+        }
+        sub
+    }
+
+    /// Compute the family of Massey products $\langle a, b, -\rangle$ for fixed `a` and `b` and
+    /// every valid third factor `c` (those with `b · c = 0`), across all computed bidegrees.
+    ///
+    /// `a` and `b` are taken in $\Ext(k, k)$; the third factor ranges over $\Ext(M, k)$. The
+    /// caller must have resolved `M` and the unit far enough. This assumes `a · b = 0` (so that the
+    /// bracket is defined); it is not verified.
+    pub fn massey_family(
+        &self,
+        a: &BidegreeElement,
+        b: &BidegreeElement,
+    ) -> Vec<(BidegreeElement, MasseyResult)> {
+        let shift = Self::massey_shift(a, b);
+        let offset_a =
+            self.unit()
+                .module(a.degree().s())
+                .generator_offset(a.degree().t(), a.degree().t(), 0);
+        let b_hom = self.massey_b_hom(b, shift);
+
+        let mut results = Vec::new();
+        for c_deg in self.resolution().iter_nonzero_stem() {
+            let Some((answers, kernel, tot)) = self.massey_at(a, b, &b_hom, shift, offset_a, c_deg)
+            else {
+                continue;
+            };
+            for row in kernel.iter() {
+                let c = BidegreeElement::new(c_deg, row.to_owned());
+                let representative = self.massey_contract(&answers, row, tot);
+                let indeterminacy = self.massey_indeterminacy(a, &c, tot);
+                results.push((
+                    c,
+                    MasseyResult {
+                        representative,
+                        indeterminacy,
+                    },
+                ));
+            }
+        }
+        results
+    }
+
+    /// Compute the triple Massey product $\langle a, b, c\rangle$.
+    ///
+    /// `a` and `b` are taken in $\Ext(k, k)$ and `c` in $\Ext(M, k)$. Returns `None` if
+    /// `b · c != 0` (so the bracket is undefined). This assumes `a · b = 0`; it is not verified.
+    pub fn massey(
+        &self,
+        a: &BidegreeElement,
+        b: &BidegreeElement,
+        c: &BidegreeElement,
+    ) -> Option<MasseyResult> {
+        let shift = Self::massey_shift(a, b);
+        let offset_a =
+            self.unit()
+                .module(a.degree().s())
+                .generator_offset(a.degree().t(), a.degree().t(), 0);
+        let b_hom = self.massey_b_hom(b, shift);
+
+        let (answers, kernel, tot) = self.massey_at(a, b, &b_hom, shift, offset_a, c.degree())?;
+
+        // The bracket is defined exactly when b · c = 0, i.e. c lies in the kernel of (· b).
+        let mut reduced = c.vec().to_owned();
+        kernel.reduce(reduced.as_slice_mut());
+        if !reduced.is_zero() {
+            return None;
+        }
+
+        let representative = self.massey_contract(&answers, c.vec(), tot);
+        let indeterminacy = self.massey_indeterminacy(a, c, tot);
+        Some(MasseyResult {
+            representative,
+            indeterminacy,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sseq::coordinates::BidegreeGenerator;
+
+    use super::*;
+    use crate::utils::construct_standard;
+
+    #[test]
+    fn test_sphere_massey() {
+        let res = Arc::new(construct_standard::<false, _, _>("S_2", None).unwrap());
+        res.compute_through_stem(Bidegree::n_s(6, 5));
+        let alg = ExtAlgebra::new(Arc::clone(&res), res, true);
+
+        let h0 = alg.generator(BidegreeGenerator::new(Bidegree::n_s(0, 1), 0));
+        let h1 = alg.generator(BidegreeGenerator::new(Bidegree::n_s(1, 1), 0));
+
+        // The classic relation <h0, h1, h0> = h1^2, the generator of Ext^{2,4} at (2, 2).
+        let bracket = alg
+            .massey(&h0, &h1, &h0)
+            .expect("<h0, h1, h0> should be defined");
+        assert_eq!(bracket.representative.degree(), Bidegree::n_s(2, 2));
+        assert_eq!(alg.dimension(Bidegree::n_s(2, 2)), 1);
+        assert!(
+            !bracket.representative.vec().is_zero(),
+            "<h0, h1, h0> = h1^2 should be nonzero"
+        );
+
+        let h1_sq = alg.multiply(&h1, &h1);
+        assert_eq!(
+            bracket.representative.vec().iter().collect::<Vec<_>>(),
+            h1_sq.vec().iter().collect::<Vec<_>>(),
+            "<h0, h1, h0> should equal h1^2"
+        );
+        // The indeterminacy a·Ext + Ext·c vanishes here, so the bracket is a single class.
+        assert_eq!(bracket.indeterminacy.dimension(), 0);
+
+        // <h0, h1, h1> is undefined: h1 · h1 = h1^2 != 0, so h1 is not a valid third factor.
+        assert!(
+            alg.massey(&h0, &h1, &h1).is_none(),
+            "<h0, h1, h1> should be undefined since h1^2 != 0"
+        );
+    }
+}

--- a/ext/src/ext_algebra/mod.rs
+++ b/ext/src/ext_algebra/mod.rs
@@ -19,6 +19,7 @@
 //! The secondary differential ($d_2$) and the $\Mod_{C\lambda^2}$ secondary product live in the
 //! [`secondary`] submodule ([`SecondaryExtAlgebra`](secondary::SecondaryExtAlgebra)).
 
+pub mod massey;
 pub mod secondary;
 
 use std::sync::Arc;

--- a/ext/src/ext_algebra/mod.rs
+++ b/ext/src/ext_algebra/mod.rs
@@ -15,6 +15,11 @@
 //! computes the products of the multiplier with *all* classes of $\Ext(k, k)$. We cache one such
 //! map per *generator* of $\Ext(M, k)$ (keyed by [`BidegreeGenerator`]); a product by a general
 //! class is assembled at request time as the corresponding linear combination of generator maps.
+//!
+//! The secondary differential ($d_2$) and the $\Mod_{C\lambda^2}$ secondary product live in the
+//! [`secondary`] submodule ([`SecondaryExtAlgebra`](secondary::SecondaryExtAlgebra)).
+
+pub mod secondary;
 
 use std::sync::Arc;
 
@@ -69,6 +74,18 @@ impl<CC: FreeChainComplex> ExtAlgebra<CC> {
             is_unit,
             products: DashMap::new(),
         }
+    }
+
+    /// Build an [`ExtAlgebra`] for resolution-*intrinsic* operations that do not involve products
+    /// (notably the secondary `d2` differential), using the resolution itself in place of a unit.
+    ///
+    /// This avoids the unit-resolution setup (and any associated prompt) that
+    /// [`from_resolution`](Self::from_resolution) performs. The product methods
+    /// ([`multiply`](Self::multiply) etc.) and the unit-side queries are only meaningful here when
+    /// `M == k`; for products with `M != k`, build with [`from_resolution`](Self::from_resolution)
+    /// or [`new`](Self::new) instead.
+    pub fn without_unit(resolution: Arc<CC>) -> Self {
+        Self::new(Arc::clone(&resolution), resolution, true)
     }
 
     pub fn resolution(&self) -> &Arc<CC> {

--- a/ext/src/ext_algebra/secondary.rs
+++ b/ext/src/ext_algebra/secondary.rs
@@ -1,0 +1,305 @@
+//! The secondary ($d_2$) layer of [`ExtAlgebra`].
+//!
+//! [`SecondaryExtAlgebra`] composes an [`ExtAlgebra`] with the secondary resolutions of `M` and
+//! the unit `k`, and exposes:
+//! - the secondary differential [`d2`](SecondaryExtAlgebra::d2) (and the survival check
+//!   [`survives`](SecondaryExtAlgebra::survives)),
+//! - the $E_3$-page data [`page_data`](SecondaryExtAlgebra::page_data), and
+//! - the $\Mod_{C\lambda^2}$ secondary product
+//!   [`secondary_multiply_into`](SecondaryExtAlgebra::secondary_multiply_into).
+//!
+//! These wrap [`SecondaryResolution`] and [`SecondaryResolutionHomomorphism`]; no new linear
+//! algebra is implemented here. The layer is split out from [`ExtAlgebra`] because the secondary
+//! machinery requires `CC::Algebra: PairAlgebra`, a bound the primary layer does not impose.
+
+use std::sync::{Arc, OnceLock};
+
+use algebra::pair_algebra::PairAlgebra;
+use dashmap::DashMap;
+use fp::{matrix::Subquotient, prime::Prime, vector::FpVector};
+use sseq::coordinates::{Bidegree, BidegreeElement};
+
+use super::ExtAlgebra;
+use crate::{
+    chain_complex::FreeChainComplex,
+    resolution_homomorphism::ResolutionHomomorphism,
+    secondary::{
+        LAMBDA_BIDEGREE, SecondaryLift, SecondaryResolution, SecondaryResolutionHomomorphism,
+    },
+};
+
+/// A single secondary product `x · y` in $\Mod_{C\lambda^2}$, where `y` is an $E_3$-surviving
+/// class. See [`SecondaryExtAlgebra::secondary_multiply_into`].
+pub struct SecondaryProduct {
+    /// The multiplicand: an $E_3$-surviving generator of the unit at the queried bidegree `b`.
+    pub source: BidegreeElement,
+    /// The $\Ext$ part of the product, in bidegree `b + x.degree()`.
+    pub ext_part: FpVector,
+    /// The $\lambda$ part of the product, in bidegree `b + x.degree() + LAMBDA_BIDEGREE`, already
+    /// reduced by the image of $d_2$.
+    pub lambda_part: FpVector,
+}
+
+/// The secondary layer over an [`ExtAlgebra`]: the $d_2$ differential and the $\Mod_{C\lambda^2}$
+/// product. See the [module documentation](self).
+pub struct SecondaryExtAlgebra<CC: FreeChainComplex>
+where
+    CC::Algebra: PairAlgebra,
+{
+    alg: Arc<ExtAlgebra<CC>>,
+    res_lift: Arc<SecondaryResolution<CC>>,
+    /// `Arc`-shared with `res_lift` when `M == k`.
+    unit_lift: Arc<SecondaryResolution<CC>>,
+    /// $E_3$ page of the resolution, filled by [`extend_all`](Self::extend_all).
+    res_sseq: OnceLock<Arc<sseq::Sseq<2, sseq::Adams>>>,
+    /// $E_3$ page of the unit, filled by [`extend_all`](Self::extend_all).
+    unit_sseq: OnceLock<Arc<sseq::Sseq<2, sseq::Adams>>>,
+    /// Secondary lift of the multiplication map, cached per multiplier class `(degree, coords)`.
+    secondary_products: DashMap<(Bidegree, Vec<u32>), Arc<SecondaryResolutionHomomorphism<CC, CC>>>,
+}
+
+impl<CC: FreeChainComplex> SecondaryExtAlgebra<CC>
+where
+    CC::Algebra: PairAlgebra,
+{
+    /// Build the secondary layer over `alg`. Construction is cheap; call [`extend_all`](Self::extend_all)
+    /// to actually compute the secondary resolutions and $E_3$ pages.
+    pub fn new(alg: Arc<ExtAlgebra<CC>>) -> Self {
+        let res_lift = Arc::new(SecondaryResolution::new(Arc::clone(alg.resolution())));
+        let unit_lift = if alg.is_unit() {
+            Arc::clone(&res_lift)
+        } else {
+            Arc::new(SecondaryResolution::new(Arc::clone(alg.unit())))
+        };
+        Self {
+            alg,
+            res_lift,
+            unit_lift,
+            res_sseq: OnceLock::new(),
+            unit_sseq: OnceLock::new(),
+            secondary_products: DashMap::new(),
+        }
+    }
+
+    /// Extend the secondary resolutions as far as the underlying resolutions allow, then compute
+    /// the $E_3$ pages. Must be called before [`d2`](Self::d2), [`page_data`](Self::page_data) or
+    /// [`secondary_multiply_into`](Self::secondary_multiply_into).
+    pub fn extend_all(&self) {
+        self.res_lift.extend_all();
+        if !self.alg.is_unit() {
+            self.unit_lift.extend_all();
+        }
+
+        let res_sseq = Arc::new(self.res_lift.e3_page());
+        let unit_sseq = if self.alg.is_unit() {
+            Arc::clone(&res_sseq)
+        } else {
+            Arc::new(self.unit_lift.e3_page())
+        };
+        let _ = self.res_sseq.set(res_sseq);
+        let _ = self.unit_sseq.set(unit_sseq);
+    }
+
+    /// Sharding entry point: compute only the secondary resolution data for filtration `s`,
+    /// distributed across machines sharing a save directory (see the `secondary` example docs).
+    /// Mirrors [`SecondaryLift::compute_partial`]. Returns before any $E_3$ page is built.
+    pub fn compute_partial(&self, s: i32) {
+        self.res_lift.compute_partial(s);
+        if !self.alg.is_unit() {
+            self.unit_lift.compute_partial(s);
+        }
+    }
+
+    /// The primary [`ExtAlgebra`] this is built on.
+    pub fn ext_algebra(&self) -> &Arc<ExtAlgebra<CC>> {
+        &self.alg
+    }
+
+    fn prime(&self) -> fp::prime::ValidPrime {
+        self.alg.prime()
+    }
+
+    /// The secondary differential $d_2(x)$, a class in bidegree `(n - 1, s + 2)`.
+    ///
+    /// Returns `None` if the target bidegree has not been computed (so $d_2$ is unknown). A
+    /// computed-but-zero differential is `Some` of a zero class.
+    pub fn d2(&self, x: &BidegreeElement) -> Option<BidegreeElement> {
+        let b = x.degree();
+        let target = b + Bidegree::n_s(-1, 2);
+        let res = self.res_lift.underlying();
+        if !(b.t() > 0 && res.has_computed_bidegree(target)) {
+            return None;
+        }
+
+        let target_dim = res.number_of_gens_in_bidegree(target);
+        let mut out = FpVector::new(self.prime(), target_dim);
+
+        // `m[i]` is the d2 of the i-th generator of `b`, as a vector at `target`. This is exactly
+        // the matrix `SecondaryResolution::e3_page` reads to install d2 differentials.
+        let m = self.res_lift.homotopy(b.s() + 2).homotopies.hom_k(b.t());
+        if !m.is_empty() && !m[0].is_empty() {
+            let p = self.prime().as_u32();
+            for (i, c) in x.vec().iter_nonzero() {
+                for (k, &v) in m[i].iter().enumerate() {
+                    out.add_basis_element(k, (c * v) % p);
+                }
+            }
+        }
+        Some(BidegreeElement::new(target, out))
+    }
+
+    /// Whether `x` is a $d_2$-cycle (a permanent class through $E_3$). Treats an uncomputed $d_2$
+    /// target as "survives" (there is nothing for it to hit).
+    pub fn survives(&self, x: &BidegreeElement) -> bool {
+        self.d2(x).is_none_or(|d| d.vec().is_zero())
+    }
+
+    /// The $E_3$-page subquotient of $\Ext(M, k)$ at bidegree `b`.
+    pub fn page_data(&self, b: Bidegree) -> &Subquotient {
+        Self::e3_page_data(self.res_sseq.get().expect("call extend_all() first"), b)
+    }
+
+    /// The $E_3$-page subquotient of the unit $\Ext(k, k)$ at bidegree `b`.
+    pub fn unit_page_data(&self, b: Bidegree) -> &Subquotient {
+        Self::e3_page_data(self.unit_sseq.get().expect("call extend_all() first"), b)
+    }
+
+    fn e3_page_data(sseq: &sseq::Sseq<2, sseq::Adams>, b: Bidegree) -> &Subquotient {
+        let d = sseq.page_data(b);
+        &d[std::cmp::min(3, d.len() - 1)]
+    }
+}
+
+impl<CC: FreeChainComplex + crate::chain_complex::AugmentedChainComplex> SecondaryExtAlgebra<CC>
+where
+    CC::Algebra: PairAlgebra,
+{
+    /// The secondary lift of multiplication by `x`, built and cached per multiplier class. The
+    /// returned lift is *not* extended; [`secondary_multiply_into`](Self::secondary_multiply_into)
+    /// extends it as needed. Exposed so callers can drive sharded computation
+    /// (`lift.underlying().extend_all()` then `lift.compute_partial(s)`).
+    pub fn secondary_product_lift(
+        &self,
+        x: &BidegreeElement,
+    ) -> Arc<SecondaryResolutionHomomorphism<CC, CC>> {
+        let shift = x.degree();
+        let coords: Vec<u32> = x.vec().iter().collect();
+        let key = (shift, coords.clone());
+
+        if let Some(map) = self.secondary_products.get(&key) {
+            return Arc::clone(&map);
+        }
+
+        let name = format!(
+            "prod_{}_{}_{}",
+            shift.n(),
+            shift.s(),
+            coords
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join("_")
+        );
+        let underlying = Arc::new(ResolutionHomomorphism::from_class(
+            name,
+            Arc::clone(self.alg.resolution()),
+            Arc::clone(self.alg.unit()),
+            shift,
+            &coords,
+        ));
+        let lift = Arc::new(SecondaryResolutionHomomorphism::new(
+            Arc::clone(&self.res_lift),
+            Arc::clone(&self.unit_lift),
+            underlying,
+        ));
+
+        Arc::clone(self.secondary_products.entry(key).or_insert(lift).value())
+    }
+
+    /// The secondary product of `x` with every $E_3$-surviving class of the unit at bidegree `b`,
+    /// computed in $\Mod_{C\lambda^2}$.
+    ///
+    /// Returns one [`SecondaryProduct`] per surviving generator at `b`; the $\lambda$ part is
+    /// already reduced by the image of $d_2$. The caller must have run [`extend_all`](Self::extend_all)
+    /// and computed both resolutions far enough.
+    pub fn secondary_multiply_into(
+        &self,
+        x: &BidegreeElement,
+        b: Bidegree,
+    ) -> Vec<SecondaryProduct> {
+        let p = self.prime();
+        let shift = x.degree();
+        let res_sseq = self.res_sseq.get().expect("call extend_all() first");
+
+        let ext_dim = self.alg.resolution().number_of_gens_in_bidegree(b + shift);
+        let lambda_dim = self
+            .alg
+            .resolution()
+            .number_of_gens_in_bidegree(b + shift + LAMBDA_BIDEGREE);
+
+        let page = self.unit_page_data(b);
+        let n = page.subspace_dimension();
+        if n == 0 {
+            return Vec::new();
+        }
+
+        let lift = self.secondary_product_lift(x);
+        lift.underlying().extend_all();
+        lift.extend_all();
+
+        let mut outputs = vec![FpVector::new(p, ext_dim + lambda_dim); n];
+        lift.hom_k(
+            Some(&**res_sseq),
+            b,
+            page.subspace_gens(),
+            outputs.iter_mut().map(FpVector::as_slice_mut),
+        );
+
+        page.subspace_gens()
+            .zip(outputs)
+            .map(|(g, out)| SecondaryProduct {
+                source: BidegreeElement::new(b, g.to_owned()),
+                ext_part: out.slice(0, ext_dim).to_owned(),
+                lambda_part: out.slice(ext_dim, ext_dim + lambda_dim).to_owned(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sseq::coordinates::BidegreeGenerator;
+
+    use super::*;
+    use crate::utils::construct_standard;
+
+    #[test]
+    fn test_sphere_d2() {
+        let res = Arc::new(construct_standard::<false, _, _>("S_2", None).unwrap());
+        // Far enough to reach the first Adams differential d2(h4) = h0 h3^2 at (14, 3).
+        res.compute_through_stem(Bidegree::n_s(16, 6));
+        let alg = Arc::new(ExtAlgebra::new(Arc::clone(&res), res, true));
+        let sec = SecondaryExtAlgebra::new(alg);
+        sec.extend_all();
+
+        let alg = sec.ext_algebra();
+
+        // h_0, h_1, h_2 are permanent cycles.
+        for (n, s) in [(0, 1), (1, 1), (3, 1)] {
+            let h = alg.generator(BidegreeGenerator::new(Bidegree::n_s(n, s), 0));
+            assert!(sec.survives(&h), "h at (n={n}, s={s}) should survive d2");
+            assert!(
+                sec.d2(&h).is_none_or(|d| d.vec().is_zero()),
+                "d2 of a permanent class should vanish"
+            );
+        }
+
+        // The first Adams differential: d2(h4) = h0 h3^2, the generator of Ext^{3,17} at (14, 3).
+        let h4 = alg.generator(BidegreeGenerator::new(Bidegree::n_s(15, 1), 0));
+        let d = sec.d2(&h4).expect("d2(h4) target should be computed");
+        assert_eq!(d.degree(), Bidegree::n_s(14, 3));
+        assert_eq!(alg.dimension(Bidegree::n_s(14, 3)), 1);
+        assert!(!d.vec().is_zero(), "d2(h4) = h0 h3^2 should be nonzero");
+        assert!(!sec.survives(&h4), "h4 should not survive d2");
+    }
+}

--- a/ext/src/ext_algebra/secondary.rs
+++ b/ext/src/ext_algebra/secondary.rs
@@ -14,17 +14,23 @@
 
 use std::sync::{Arc, OnceLock};
 
-use algebra::pair_algebra::PairAlgebra;
+use algebra::{module::Module, pair_algebra::PairAlgebra};
 use dashmap::DashMap;
-use fp::{matrix::Subquotient, prime::Prime, vector::FpVector};
+use fp::{
+    matrix::{Matrix, Subquotient, Subspace},
+    prime::Prime,
+    vector::FpVector,
+};
+use itertools::Itertools;
 use sseq::coordinates::{Bidegree, BidegreeElement};
 
 use super::ExtAlgebra;
 use crate::{
-    chain_complex::FreeChainComplex,
+    chain_complex::{ChainHomotopy, FreeChainComplex},
     resolution_homomorphism::ResolutionHomomorphism,
     secondary::{
-        LAMBDA_BIDEGREE, SecondaryLift, SecondaryResolution, SecondaryResolutionHomomorphism,
+        LAMBDA_BIDEGREE, SecondaryChainHomotopy, SecondaryLift, SecondaryResolution,
+        SecondaryResolutionHomomorphism,
     },
 };
 
@@ -156,18 +162,20 @@ where
 
     /// The $E_3$-page subquotient of $\Ext(M, k)$ at bidegree `b`.
     pub fn page_data(&self, b: Bidegree) -> &Subquotient {
-        Self::e3_page_data(self.res_sseq.get().expect("call extend_all() first"), b)
+        e3_page_data(self.res_sseq.get().expect("call extend_all() first"), b)
     }
 
     /// The $E_3$-page subquotient of the unit $\Ext(k, k)$ at bidegree `b`.
     pub fn unit_page_data(&self, b: Bidegree) -> &Subquotient {
-        Self::e3_page_data(self.unit_sseq.get().expect("call extend_all() first"), b)
+        e3_page_data(self.unit_sseq.get().expect("call extend_all() first"), b)
     }
+}
 
-    fn e3_page_data(sseq: &sseq::Sseq<2, sseq::Adams>, b: Bidegree) -> &Subquotient {
-        let d = sseq.page_data(b);
-        &d[std::cmp::min(3, d.len() - 1)]
-    }
+/// The $E_3$-page subquotient recorded by `sseq` at bidegree `b` (clamped to the last computed
+/// page). Promotes the `get_page_data` helper that the secondary examples duplicated.
+fn e3_page_data(sseq: &sseq::Sseq<2, sseq::Adams>, b: Bidegree) -> &Subquotient {
+    let d = sseq.page_data(b);
+    &d[std::cmp::min(3, d.len() - 1)]
 }
 
 impl<CC: FreeChainComplex + crate::chain_complex::AugmentedChainComplex> SecondaryExtAlgebra<CC>
@@ -263,6 +271,499 @@ where
                 lambda_part: out.slice(ext_dim, ext_dim + lambda_dim).to_owned(),
             })
             .collect()
+    }
+
+    /// The underlying multiplication map for `class` and its secondary lift, named for
+    /// bookkeeping/saving. `source`/`target` are the secondary resolutions the lift bridges.
+    fn massey_secondary_map(
+        &self,
+        source: &Arc<SecondaryResolution<CC>>,
+        target: &Arc<SecondaryResolution<CC>>,
+        name: &str,
+        class: &BidegreeElement,
+    ) -> Arc<SecondaryResolutionHomomorphism<CC, CC>> {
+        let coords: Vec<u32> = class.vec().iter().collect();
+        let map_name = format!(
+            "massey_{name}_{}_{}",
+            class.degree().n(),
+            class.degree().s()
+        );
+        let underlying = Arc::new(ResolutionHomomorphism::from_class(
+            map_name,
+            source.underlying(),
+            target.underlying(),
+            class.degree(),
+            &coords,
+        ));
+        Arc::new(SecondaryResolutionHomomorphism::new(
+            Arc::clone(source),
+            Arc::clone(target),
+            underlying,
+        ))
+    }
+
+    /// The λ-part map of `class` (one filtration up), bridging the same endpoints as `lift`.
+    fn massey_lambda_map(
+        &self,
+        lift: &Arc<SecondaryResolutionHomomorphism<CC, CC>>,
+        name: &str,
+        class: &BidegreeElement,
+    ) -> Arc<ResolutionHomomorphism<CC, CC>> {
+        let coords: Vec<u32> = class.vec().iter().collect();
+        let map_name = format!(
+            "massey_{name}_lambda_{}_{}",
+            class.degree().n(),
+            class.degree().s()
+        );
+        Arc::new(ResolutionHomomorphism::from_class(
+            map_name,
+            lift.source(),
+            lift.target(),
+            class.degree(),
+            &coords,
+        ))
+    }
+
+    /// Build the data for the secondary Massey product family $\langle a, b, -\rangle$, computed in
+    /// $\Mod_{C\lambda^2}$.
+    ///
+    /// `a` is taken in $\Ext(M, k)$ and `b` in $\Ext(k, k)$; the third factor will range over
+    /// $\Ext(M, k)$. Each of `a` and `b` may carry a $\lambda$ part — its lift into
+    /// $\Mod_{C\lambda^2}$ — supplied as a class one filtration up (at `degree + LAMBDA_BIDEGREE`);
+    /// pass `None` for a zero $\lambda$ part. This assumes `a · b = 0` in $\Mod_{C\lambda^2}$; it is
+    /// **not** verified.
+    ///
+    /// Construction builds the underlying multiplication maps, their secondary lifts, the
+    /// null-homotopy of `a · b`, and the secondary chain homotopy, extending the resolutions as far
+    /// as they allow. Drive the result with [`SecondaryMassey::extend`] (or
+    /// [`compute_partial`](SecondaryMassey::compute_partial) for sharded computation) before reading
+    /// off [`family`](SecondaryMassey::family).
+    pub fn secondary_massey(
+        &self,
+        a: &BidegreeElement,
+        a_lambda: Option<&BidegreeElement>,
+        b: &BidegreeElement,
+        b_lambda: Option<&BidegreeElement>,
+    ) -> SecondaryMassey<CC> {
+        let p = self.prime();
+        let resolution = Arc::clone(self.alg.resolution());
+        let unit = Arc::clone(self.alg.unit());
+        let is_unit = self.alg.is_unit();
+
+        // Reach the λ bidegree of each input, as the example's `get_hom` does per map. (We use a
+        // rectangle here rather than a stem, since `compute_through_stem` is concrete-only; for the
+        // small input bidegrees this is a no-op when the resolutions are already computed.)
+        resolution.compute_through_bidegree(a.degree() + LAMBDA_BIDEGREE);
+        unit.compute_through_bidegree(b.degree() + LAMBDA_BIDEGREE);
+
+        // The combined (Ext + λ) class of `b`, as `product_nullhomotopy` expects. Built from the
+        // input elements before they are turned into maps below.
+        let b_class = {
+            let ext_dim = unit.number_of_gens_in_bidegree(b.degree());
+            let lambda_dim = unit.number_of_gens_in_bidegree(b.degree() + LAMBDA_BIDEGREE);
+            let mut class = FpVector::new(p, ext_dim + lambda_dim);
+            for (i, v) in b.vec().iter_nonzero() {
+                class.set_entry(i, v);
+            }
+            if let Some(bl) = b_lambda {
+                for (i, v) in bl.vec().iter_nonzero() {
+                    class.set_entry(ext_dim + i, v);
+                }
+            }
+            class
+        };
+
+        // `a: res → unit`, `b: unit → unit`.
+        let a_lift = self.massey_secondary_map(&self.res_lift, &self.unit_lift, "a", a);
+        let b_lift = self.massey_secondary_map(&self.unit_lift, &self.unit_lift, "b", b);
+        let a_lambda = a_lambda.map(|c| self.massey_lambda_map(&a_lift, "a", c));
+        let b_lambda = b_lambda.map(|c| self.massey_lambda_map(&b_lift, "b", c));
+
+        let shift = Bidegree::s_t(
+            (a_lift.underlying().shift + b_lift.underlying().shift).s(),
+            (a_lift.shift() + b_lift.shift()).t(),
+        );
+        let b_shift = b_lift.underlying().shift;
+
+        // Extend the resolutions, then the secondary resolutions, then the $E_3$ pages.
+        if !is_unit {
+            let res_max = Bidegree::n_s(
+                resolution.module(0).max_computed_degree(),
+                resolution.next_homological_degree() - 1,
+            );
+            unit.compute_through_bidegree(res_max - a_lift.underlying().shift);
+        }
+        if is_unit {
+            self.res_lift.extend_all();
+        } else {
+            maybe_rayon::join(
+                || self.res_lift.extend_all(),
+                || self.unit_lift.extend_all(),
+            );
+        }
+
+        let res_sseq = Arc::new(self.res_lift.e3_page());
+        let unit_sseq = if is_unit {
+            Arc::clone(&res_sseq)
+        } else {
+            Arc::new(self.unit_lift.e3_page())
+        };
+
+        // Extend the homomorphisms.
+        maybe_rayon::scope(|s| {
+            s.spawn(|_| {
+                a_lift.underlying().extend_all();
+                a_lift.extend_all();
+            });
+            s.spawn(|_| {
+                b_lift.underlying().extend_all();
+                b_lift.extend_all();
+            });
+            if let Some(a_lambda) = &a_lambda {
+                s.spawn(|_| a_lambda.extend_all());
+            }
+            if let Some(b_lambda) = &b_lambda {
+                s.spawn(|_| b_lambda.extend_all());
+            }
+        });
+
+        // The null-homotopy of `a · b`, installed as the first homotopy of the chain homotopy.
+        let chain_homotopy = Arc::new(ChainHomotopy::new(a_lift.underlying(), b_lift.underlying()));
+        chain_homotopy.initialize_homotopies((b_shift + a_lift.underlying().shift).s());
+        {
+            let v = a_lift.product_nullhomotopy(
+                a_lambda.as_deref(),
+                &res_sseq,
+                b_shift,
+                b_class.as_slice(),
+            );
+            let homotopy = chain_homotopy.homotopy(b_shift.s() + a_lift.underlying().shift.s() - 1);
+            let htpy_source = a_lift.shift() + b_shift;
+            homotopy.extend_by_zero(htpy_source.t() - 1);
+            homotopy.add_generators_from_rows(
+                htpy_source.t(),
+                v.into_iter()
+                    .map(|x| FpVector::from_slice(p, &[x]))
+                    .collect(),
+            );
+        }
+        chain_homotopy.extend_all();
+
+        let ch_lift = SecondaryChainHomotopy::new(
+            Arc::clone(&a_lift),
+            Arc::clone(&b_lift),
+            a_lambda.clone(),
+            b_lambda.clone(),
+            Arc::clone(&chain_homotopy),
+        );
+
+        // `a_lambda` and `b_class` are only needed to build the chain homotopy above; `ch_lift`
+        // keeps the λ-part maps alive past this point.
+        SecondaryMassey {
+            alg: Arc::clone(&self.alg),
+            a_lift,
+            b_lift,
+            b_lambda,
+            chain_homotopy,
+            ch_lift,
+            unit_sseq,
+            shift,
+            b_shift,
+        }
+    }
+}
+
+/// One entry of the secondary Massey product family $\langle a, b, -\rangle$ in
+/// $\Mod_{C\lambda^2}$, as returned by [`SecondaryMassey::family`].
+///
+/// The bracket is computed up to a sign. The third factor `[third_factor] + λ·third_factor_lambda`
+/// is an $E_3$-surviving class with `b · (third factor) = 0`; the bracket representative is
+/// `[representative] + λ·representative_lambda`.
+pub struct SecondaryMasseyResult {
+    /// The $\Ext$ part of the third factor, an $E_3$-surviving class at bidegree `c`.
+    pub third_factor: BidegreeElement,
+    /// The $\lambda$ part of the third factor, at `third_factor.degree() + LAMBDA_BIDEGREE`.
+    pub third_factor_lambda: FpVector,
+    /// The $\Ext$ part of the bracket representative, at `c + shift - (1, 0)`.
+    pub representative: BidegreeElement,
+    /// The $\lambda$ part of the bracket representative, at
+    /// `representative.degree() + LAMBDA_BIDEGREE`.
+    pub representative_lambda: FpVector,
+}
+
+/// The data backing a secondary Massey product family $\langle a, b, -\rangle$, built by
+/// [`SecondaryExtAlgebra::secondary_massey`]. Drive it with [`extend`](Self::extend) (or
+/// [`compute_partial`](Self::compute_partial)) and read the brackets off with
+/// [`family`](Self::family).
+pub struct SecondaryMassey<CC: FreeChainComplex>
+where
+    CC::Algebra: PairAlgebra,
+{
+    alg: Arc<ExtAlgebra<CC>>,
+    a_lift: Arc<SecondaryResolutionHomomorphism<CC, CC>>,
+    b_lift: Arc<SecondaryResolutionHomomorphism<CC, CC>>,
+    b_lambda: Option<Arc<ResolutionHomomorphism<CC, CC>>>,
+    chain_homotopy: Arc<ChainHomotopy<CC, CC, CC>>,
+    ch_lift: SecondaryChainHomotopy<CC, CC, CC>,
+    /// $E_3$ page of the unit; the only page the readout needs.
+    unit_sseq: Arc<sseq::Sseq<2, sseq::Adams>>,
+    /// `a.degree() + b.degree()`, the total bidegree shift of the bracket.
+    shift: Bidegree,
+    /// `b.degree()`.
+    b_shift: Bidegree,
+}
+
+impl<CC: FreeChainComplex> SecondaryMassey<CC>
+where
+    CC::Algebra: PairAlgebra,
+{
+    /// Sharding entry point: compute only the secondary chain homotopy data for filtration `s`,
+    /// distributed across machines sharing a save directory (see the `secondary_massey` example).
+    pub fn compute_partial(&self, s: i32) {
+        self.ch_lift.compute_partial(s);
+    }
+
+    /// Extend the secondary chain homotopy as far as the underlying data allows. Must be called
+    /// before [`family`](Self::family).
+    pub fn extend(&self) {
+        self.ch_lift.extend_all();
+    }
+
+    /// Read off the family of secondary Massey products $\langle a, b, -\rangle$ over every
+    /// $E_3$-surviving third factor, in $\Mod_{C\lambda^2}$, up to a sign.
+    ///
+    /// One [`SecondaryMasseyResult`] per surviving generator at each computed bidegree. Requires
+    /// [`extend`](Self::extend) to have completed.
+    pub fn family(&self) -> Vec<SecondaryMasseyResult> {
+        let p = self.alg.prime();
+        let resolution = self.alg.resolution();
+        let unit = self.alg.unit();
+        let shift = self.shift;
+        let b_shift = self.b_shift;
+        let chain_homotopy = &self.chain_homotopy;
+        let ch_lift = &self.ch_lift;
+        let a = &self.a_lift;
+        let b = &self.b_lift;
+        let b_lambda = self.b_lambda.as_deref();
+        let unit_sseq = &self.unit_sseq;
+
+        let h_0 = ch_lift.algebra().p_tilde();
+
+        let mut results = Vec::new();
+
+        // Iterate through the multiplicand.
+        for c in unit.iter_stem() {
+            if !resolution.has_computed_bidegree(c + shift - Bidegree::s_t(2, 0))
+                || !resolution.has_computed_bidegree(c + shift + Bidegree::s_t(0, 1))
+            {
+                continue;
+            }
+
+            let source = c + shift - Bidegree::s_t(1, 0);
+
+            let source_num_gens = resolution.number_of_gens_in_bidegree(source);
+            let source_lambda_num_gens =
+                resolution.number_of_gens_in_bidegree(source + LAMBDA_BIDEGREE);
+
+            if source_num_gens + source_lambda_num_gens == 0 {
+                continue;
+            }
+
+            // The kernel of multiplication by `b` on the $E_3$ page.
+            let target_num_gens = unit.number_of_gens_in_bidegree(c);
+            let target_lambda_num_gens = unit.number_of_gens_in_bidegree(c + LAMBDA_BIDEGREE);
+            let target_all_gens = target_num_gens + target_lambda_num_gens;
+
+            let prod_num_gens = unit.number_of_gens_in_bidegree(c + b_shift);
+            let prod_lambda_num_gens =
+                unit.number_of_gens_in_bidegree(c + b_shift + LAMBDA_BIDEGREE);
+            let prod_all_gens = prod_num_gens + prod_lambda_num_gens;
+
+            let e3_kernel = {
+                let target_page_data = e3_page_data(unit_sseq, c);
+                let target_lambda_page_data = e3_page_data(unit_sseq, c + LAMBDA_BIDEGREE);
+                let product_lambda_page_data =
+                    e3_page_data(unit_sseq, c + b_shift + LAMBDA_BIDEGREE);
+
+                // We first compute elements whose product vanishes mod lambda, and later see what
+                // the possible lifts are. We do it this way to avoid Z/p^2 problems.
+                let e2_kernel: Subspace = {
+                    let mut product_matrix = Matrix::new(
+                        p,
+                        target_page_data.subspace_dimension(),
+                        target_num_gens + prod_num_gens,
+                    );
+
+                    let m0 = Matrix::from_vec(
+                        p,
+                        &b.underlying()
+                            .get_map(c.s() + b.underlying().shift.s())
+                            .hom_k(c.t()),
+                    );
+                    for (g, mut out) in target_page_data
+                        .subspace_gens()
+                        .zip_eq(product_matrix.iter_mut())
+                    {
+                        out.slice_mut(prod_num_gens, prod_num_gens + target_num_gens)
+                            .add(g, 1);
+                        for (i, v) in g.iter_nonzero() {
+                            out.slice_mut(0, prod_num_gens).add(m0.row(i), v);
+                        }
+                    }
+                    product_matrix.row_reduce();
+                    product_matrix.compute_kernel(prod_num_gens)
+                };
+
+                // Now compute the e3 kernel.
+                {
+                    // First add the lifts from Ext.
+                    let e2_ker_dim = e2_kernel.dimension();
+                    let mut product_matrix = Matrix::new(
+                        p,
+                        e2_ker_dim + target_lambda_page_data.quotient_dimension(),
+                        target_all_gens + prod_all_gens,
+                    );
+
+                    b.hom_k_with(
+                        b_lambda,
+                        Some(&**unit_sseq),
+                        c,
+                        e2_kernel.basis(),
+                        product_matrix
+                            .slice_mut(0, e2_ker_dim, 0, prod_all_gens)
+                            .iter_mut(),
+                    );
+                    for (v, mut t) in e2_kernel.basis().zip(product_matrix.iter_mut()) {
+                        t.slice_mut(prod_all_gens, prod_all_gens + target_num_gens)
+                            .assign(v);
+                    }
+
+                    // Now add the lambda multiples.
+                    let m = Matrix::from_vec(
+                        p,
+                        &b.underlying()
+                            .get_map(b_shift.s() + c.s() + 1)
+                            .hom_k(c.t() + 1),
+                    );
+
+                    let mut count = 0;
+                    for (i, &v) in target_lambda_page_data.quotient_pivots().iter().enumerate() {
+                        if v >= 0 {
+                            continue;
+                        }
+                        let mut row = product_matrix.row_mut(e2_ker_dim + count as usize);
+                        row.add_basis_element(prod_all_gens + target_num_gens + i, 1);
+                        row.slice_mut(prod_num_gens, prod_all_gens).add(m.row(i), 1);
+                        product_lambda_page_data
+                            .reduce_by_quotient(row.slice_mut(prod_num_gens, prod_all_gens));
+                        count += 1;
+                    }
+
+                    product_matrix.row_reduce();
+                    product_matrix.compute_kernel(prod_all_gens)
+                }
+            };
+
+            if e3_kernel.dimension() == 0 {
+                continue;
+            }
+
+            let m0 = chain_homotopy.homotopy(source.s()).hom_k(c.t());
+            let mt = Matrix::from_vec(p, &chain_homotopy.homotopy(source.s() + 1).hom_k(c.t() + 1));
+            let m1 = Matrix::from_vec(
+                p,
+                &ch_lift.homotopies()[source.s() + 1].homotopies.hom_k(c.t()),
+            );
+            let mp = Matrix::from_vec(
+                p,
+                &resolution
+                    .filtration_one_product(1, h_0, Bidegree::s_t(source.s(), c.t() + shift.t()))
+                    .unwrap(),
+            );
+            let ma = a
+                .underlying()
+                .get_map(source.s())
+                .hom_k(c.t() + b_shift.t());
+            let mb = b.underlying().get_map(c.s() + b_shift.s()).hom_k(c.t());
+
+            for g in e3_kernel.iter() {
+                let third_factor =
+                    BidegreeElement::new(c, g.restrict(0, target_num_gens).to_owned());
+                let third_factor_lambda = g.restrict(target_num_gens, target_all_gens).to_owned();
+
+                let mut scratch0: Vec<u32> = vec![0; source_num_gens];
+                let mut scratch1 = FpVector::new(p, source_lambda_num_gens);
+
+                // First deal with the null-homotopy of ab.
+                for (i, v) in g.restrict(0, target_num_gens).iter_nonzero() {
+                    scratch0
+                        .iter_mut()
+                        .zip_eq(&m0[i])
+                        .for_each(|(a, b)| *a += v * b);
+                    scratch1.as_slice_mut().add(m1.row(i), v);
+                }
+                for (i, v) in g.restrict(target_num_gens, target_all_gens).iter_nonzero() {
+                    scratch1.as_slice_mut().add(mt.row(i), v);
+                }
+                // Now do the -1 part of the null-homotopy of bc.
+                {
+                    let sign = p * p - 1;
+                    let out = b.product_nullhomotopy(b_lambda, unit_sseq, c, g);
+                    for (i, v) in out.iter_nonzero() {
+                        scratch0
+                            .iter_mut()
+                            .zip_eq(&ma[i])
+                            .for_each(|(a, b)| *a += v * b * sign);
+                    }
+                }
+
+                for (i, v) in scratch0.iter().enumerate() {
+                    let extra = *v / p;
+                    scratch1.as_slice_mut().add(mp.row(i), extra % p);
+                }
+
+                let representative = BidegreeElement::new(
+                    source,
+                    FpVector::from_slice(p, &scratch0.iter().map(|x| *x % p).collect::<Vec<_>>()),
+                );
+
+                // Then deal with the rest of the null-homotopy of bc. This is just the
+                // null-homotopy of 2.
+                let mut scratch0 = vec![0u32; prod_num_gens];
+                for (i, v) in g.restrict(0, target_num_gens).iter_nonzero() {
+                    scratch0
+                        .iter_mut()
+                        .zip_eq(&mb[i])
+                        .for_each(|(a, b)| *a += v * b);
+                }
+                for (i, v) in scratch0.iter().enumerate() {
+                    let extra = (*v / p) % p;
+                    if extra == 0 {
+                        continue;
+                    }
+                    for gen_idx in 0..source_lambda_num_gens {
+                        let m = a.underlying().get_map((source + LAMBDA_BIDEGREE).s());
+                        let dx = m.output((source + LAMBDA_BIDEGREE).t(), gen_idx);
+                        let idx = unit.module((c + shift).s()).operation_generator_to_index(
+                            1,
+                            h_0,
+                            (c + shift).t(),
+                            i,
+                        );
+                        scratch1.add_basis_element(gen_idx, dx.entry(idx));
+                    }
+                }
+
+                results.push(SecondaryMasseyResult {
+                    third_factor,
+                    third_factor_lambda,
+                    representative,
+                    representative_lambda: scratch1,
+                });
+            }
+        }
+
+        results
     }
 }
 

--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -168,6 +168,7 @@
 #![deny(clippy::use_self, unsafe_op_in_unsafe_fn)]
 
 pub mod chain_complex;
+pub mod ext_algebra;
 pub mod resolution;
 pub mod resolution_homomorphism;
 pub mod save;


### PR DESCRIPTION
## Summary

Phase 4 of the bigraded-algebra layer: **secondary Massey products** in $\Mod_{C\lambda^2}$. Adds, in `ext_algebra/secondary.rs`:

- **`SecondaryExtAlgebra::secondary_massey(a, a_λ, b, b_λ)`** — builds the data for the family $\langle a, b, -\rangle$. `a` is taken in $\Ext(M, k)$ and `b` in $\Ext(k, k)$; each may carry a $\lambda$ part (its $\Mod_{C\lambda^2}$ lift). Construction builds the underlying multiplication maps, their secondary lifts, the null-homotopy of `a · b`, and the secondary chain homotopy, extending the resolutions as needed. Assumes `a · b = 0` (not verified).
- **`SecondaryMassey`** — the returned state. Driven with `extend()` (or `compute_partial(s)` for the per-`s` **sharding** workflow), then read off with `family()`.
- **`SecondaryMassey::family()`** — the full $\Mod_{C\lambda^2}$ readout: the two-stage $E_3$ kernel (with its $\mathbb{Z}/p^2$ handling), the bracket assembly via `product_nullhomotopy`, the $(-1)^{s't}$ sign twists, and the $\lambda$-part construction. One `SecondaryMasseyResult` per surviving third factor.

This wraps `SecondaryChainHomotopy` and `SecondaryResolutionHomomorphism` — no new linear algebra. The entire readout loop of the example is ported verbatim into the library; the library returns structured data and does no I/O. The duplicated `get_page_data` helper is promoted to a module-level `e3_page_data`.

> Stacked on #10 (Phase 3), which is stacked on #9 (Phase 2) → #8 (Phase 1). This PR targets the Phase 3 branch; merge #8, #9, #10 first.

## Example refactored

- `secondary_massey.rs` keeps the prompts (module, the a/b Ext + λ parts, the display names) and the sharding branch, and builds the display names locally. The lift/chain-homotopy plumbing and the ~250-line readout loop are replaced by `secondary_massey` + `family`. Output is **byte-identical** to the pre-refactor version (verified on `S_2`: $\langle [h_0], [h_1], -\rangle$, 45 brackets, exact match against the original run with identical stdin and save dir).

## Test plan

- [x] `cargo build -p ext --examples` / `cargo clippy -p ext --examples` clean; `cargo +nightly fmt --all --check` clean
- [x] `cargo test -p ext` — existing `ext_algebra` tests (`test_sphere_products`, `test_sphere_d2`, `test_sphere_massey`) all pass
- [x] `cargo run --example secondary_massey` diffed byte-for-byte against the original on `S_2`

## Notes

`secondary_massey` uses `compute_through_bidegree` (the generic trait method) rather than the concrete-only `compute_through_stem` for its internal resolution extension; for the small input bidegrees this is a no-op when the resolutions are already computed, so output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYWcvWZPm3YJkVpCmeGYsP)_